### PR TITLE
Rewrite the Progress Component using <meter> tag

### DIFF
--- a/Plot/Components/Pages/ProgressBar.test.razor
+++ b/Plot/Components/Pages/ProgressBar.test.razor
@@ -1,10 +1,14 @@
 @page "/test/progress-bar"
 <PageTitle>Progress Bar Test</PageTitle>
 
-<ProgressBar iconString="fa-solid fa-chevron-down" mainLabel="Men's" barColor="#AAD9FF" barMax=480 barValue=290 barLabel="290/480 LF"/>
-<ProgressBar mainLabel="Pants" barColor="#AAD9FF" barMax=100 barValue=20 barLabel="20/100 LF"/>
-<ProgressBar mainLabel="Shirts" barColor="#AAD9FF" barMax=100 barValue=30 barLabel="30/100 LF"/>
-<ProgressBar mainLabel="Shoes" barColor="#AAD9FF" barMax=100 barValue=60 barLabel="60/100 LF"/>
-<ProgressBar mainLabel="Socks" barColor="#AAD9FF" barMax=80 barValue=80 barLabel="80/80 LF"/>
-<ProgressBar mainLabel="Jackets" barColor="#AAD9FF" barMax=100 barValue=100 barLabel="100/100 LF"/>
-<ProgressBar mainLabel="OverFill Test" barColor="#AAD9FF" barMax=100 barValue=120 barLabel="120/100 LF"/>
+<ProgressBar ID=1 iconString="fa-solid fa-chevron-down" mainLabel="Men's" barColor="#AAD9FF" barMax=480 barValue=290 barLabel="290/480 LF"/>
+<ProgressBar ID=2 mainLabel="Pants" barColor="#AAD9FF" barMax=100 barValue=20 barLabel="20/100 LF"/>
+<ProgressBar ID=3 mainLabel="Shirts" barColor="#AAD9FF" barMax=100 barValue=30 barLabel="30/100 LF"/>
+<ProgressBar ID=4 mainLabel="Shoes" barColor="#AAD9FF" barMax=100 barValue=60 barLabel="60/100 LF"/>
+<ProgressBar ID=5 mainLabel="Socks" barColor="#AAD9FF" barMax=80 barValue=80 barLabel="80/80 LF"/>
+<ProgressBar ID=6 mainLabel="Jackets" barColor="#AAD9FF" barMax=100 barValue=100 barLabel="100/100 LF"/>
+<ProgressBar ID=7 mainLabel="OverFill Test" barColor="#AAD9FF" barMax=100 barValue=120 barLabel="120/100 LF"/>
+<ProgressBar ID=8 iconString="fa-solid fa-chevron-down" mainLabel="Women's" barColor="#FFAAD6" barMax=40 barValue=20 barLabel="20/40 LF"/>
+<ProgressBar ID=9 mainLabel="Pants" barColor="#FFAAD6" barMax=40 barValue=20 barLabel="20/40 LF"/>
+<ProgressBar ID=10 iconString="fa-solid fa-chevron-down" mainLabel="Accessories" barColor="#5FBD6A" barMax=10 barValue=20 barLabel="20/10 LF"/>
+<ProgressBar ID=11 mainLabel="Belts" barColor="#5FBD6A" barMax=10 barValue=20 barLabel="20/10 LF"/>

--- a/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor
+++ b/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor
@@ -9,7 +9,7 @@
 
     <div class="col-6">
         <label for="main-progress">@barLabel</label>
-        <meter id="main-progress" bar-color=@barColor class="@_barClass" min="@barMin" max="@barMax" value="@barValue">@barValue</meter>
+        <meter class="progress-meter" id="main-progress" data-color="@barColor" min="@barMin" max="@barMax" value="@barValue">@barValue</meter>
     </div>
 </div>
 

--- a/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor
+++ b/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor
@@ -9,14 +9,21 @@
 
     <div class="col-6">
         <label for="main-progress">@barLabel</label>
-        <meter class="progress-meter" id="main-progress" data-color="@barColor" min="@barMin" max="@barMax" value="@barValue">@barValue</meter>
+        <style type="text/CSS">
+            @("#bar_" + ID)::-webkit-meter-bar,
+            @("#bar_" + ID)::-moz-meter-bar
+            {
+                background: @barColor;
+            }
+        </style>
+        <meter id="bar_@ID" class=@_barClass min="@barMin" max="@barMax" value="@barValue">@barValue</meter>
     </div>
 </div>
 
 @code {
     //ID string to pass into the main HTML ID
     [Parameter]
-    public String? ID {get; set;}
+    public String ID {get; set;}
 
     //Class string to pass into the main component HTML Class
     [Parameter]

--- a/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor
+++ b/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor
@@ -8,12 +8,8 @@
     </div>
 
     <div class="col-6">
-        <div class="progress-container @_barClass">
-            <div class="progress-container-text">
-                <div class="progress-container-text-align-center">@barLabel</div>
-            </div>
-            <div class="progress-bar-fill" style="width: @MapProgress()%; background-color: @barColor;"></div>
-        </div>
+        <label for="main-progress">@barLabel</label>
+        <meter id="main-progress" bar-color=@barColor class="@_barClass" min="@barMin" max="@barMax" value="@barValue">@barValue</meter>
     </div>
 </div>
 
@@ -38,8 +34,12 @@
     [Parameter]
     public String? barLabel {get; set;}
 
+    //Min number in the progress bar.
+    [Parameter]
+    public int barMin {get; set;} = 0;
+
     //Max number in the progress bar.
-    //Must be greater than 0.
+    //Must be greater than barMin
     [Parameter]
     public int barMax {get; set;} = 100;
 
@@ -85,6 +85,10 @@
     {
         if (usePresetFillWarnings)
         {
+            if (barMax <= barMin)
+            {
+                throw new ArgumentException("Bar Max cannot be less than Bar Min!");
+            }
             if (barValue < barMax)
             {
                 _barClass = _unFilledClass;

--- a/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor.css
+++ b/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor.css
@@ -1,16 +1,15 @@
-.progress-bar 
-{
-  display: flex;
-  flex-direction: row;
-  text-align: left;
-}
-
-.progress-container
+meter
 {
   background-color: rgba(0,0,0,0.25);
-  position: relative;
   height: 90%;
   border-radius: 50vh;
+  width: 100%;
+}
+
+label
+{
+  position: absolute;
+  padding-left: 0.5rem;
 }
 
 .progress-unfulfilled
@@ -23,25 +22,16 @@
   border: 2px dashed gold;
   background-color: black;
 }
-.progress-container-text 
-{
-  position: absolute;
-  left: 0;
-  right: 0;
-  height: 100%;
-}
 
-.progress-container-text-align-center 
+meter::-webkit-meter-bar,  /*background color of bar*/
+meter::-webkit-meter-optimum-value, 
+meter::-webkit-meter-suboptimum-value,
+meter::-webkit-meter-even-less-good-value,
+meter::-moz-meter-bar,
+meter::-moz-meter-optimum-value,
+meter::-moz-meter-suboptimum-value, 
+meter::-moz-meter-even-less-good-value
 {
-  display: flex;
-  height: 100%;
-  justify-content: left;
-  align-items: center;
-  padding: 8px 5px 5px 5px;
-}
-
-.progress-bar-fill 
-{
-  height: 100%;
-  border-radius: inherit;
+  background: attr(bar-color);
+  color: attr(bar-color);
 }

--- a/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor.css
+++ b/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor.css
@@ -1,6 +1,6 @@
 meter
 {
-  background-color: rgba(0,0,0,0.25);
+  /*background-color: rgba(0,0,0,0.25);*/
   height: 90%;
   border-radius: 50vh;
   width: 100%;
@@ -23,15 +23,8 @@ label
   background-color: black;
 }
 
-meter::-webkit-meter-bar,  /*background color of bar*/
-meter::-webkit-meter-optimum-value, 
-meter::-webkit-meter-suboptimum-value,
-meter::-webkit-meter-even-less-good-value,
-meter::-moz-meter-bar,
-meter::-moz-meter-optimum-value,
-meter::-moz-meter-suboptimum-value, 
-meter::-moz-meter-even-less-good-value
+meter::-webkit-meter-bar,
+meter::-moz-meter-bar
 {
-  background: attr(bar-color);
-  color: attr(bar-color);
+  background: violet;
 }

--- a/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor.css
+++ b/Plot/Components/PartialComponents/ProgressBar/ProgressBar.razor.css
@@ -1,6 +1,6 @@
 meter
 {
-  /*background-color: rgba(0,0,0,0.25);*/
+  background: rgba(0,0,0,0.25);
   height: 90%;
   border-radius: 50vh;
   width: 100%;
@@ -20,11 +20,5 @@ label
 .progress-overfilled
 {
   border: 2px dashed gold;
-  background-color: black;
-}
-
-meter::-webkit-meter-bar,
-meter::-moz-meter-bar
-{
-  background: violet;
+  background:black;
 }


### PR DESCRIPTION
Tested in Firefox. More inline styling rules may be needed for other browsers.
Progress bars _require_ a unique ID now, at least unique on their page, to display their colors correctly!