### PR TITLE
fix bug where text input wont return value

### DIFF
--- a/Plot/Components/Pages/TestComponents/TextInput.test.razor
+++ b/Plot/Components/Pages/TestComponents/TextInput.test.razor
@@ -1,11 +1,13 @@
+@* Originally by Luke Wollenweber  *@
 @page "/test/text-input"
 
 <PageTitle>Test</PageTitle>
 
-<TextInput Id="usernameTop" Label="Username" Placeholder="Enter your username" Value="@username"/>
-<TextInput Id="usernameSide" Label="Username" Placeholder="Enter your username" Value="@username" />
-<TextInput Id="usernameNone" Label="" Placeholder="" Value="@username" LabelOnTop="false" />
-
+<!-- Danielle Smith 3/15/2025
+changed test textinputs to show new implementation with new value binding   -->
+<TextInput Id="usernameTop" Label="Username" Placeholder="Enter your username" Value="@username" ValueChanged="@(e => username = e)" />
+<TextInput Id="usernameSide" Label="Username" Placeholder="Enter your username" Value="@username" ValueChanged="@(e => username = e)"  />
+<TextInput Id="usernameNone" Label="" Placeholder="" Value="@username" ValueChanged="@(e => username = e)"  LabelOnTop="false" />
 
 @code {
     private string username = ""; // Define the username variable

--- a/Plot/Components/PartialComponents/TextInput/TextInput.razor
+++ b/Plot/Components/PartialComponents/TextInput/TextInput.razor
@@ -64,13 +64,6 @@
         DotNetHelper?.Dispose();
     }
 
-    private async Task OnInputChange(ChangeEventArgs e)
-    {
-        Value = e.Value?.ToString() ?? "";
-        await ValueChanged.InvokeAsync(Value);
-    }
-
-
     // Component initialization
     protected override void OnInitialized()
     {

--- a/Plot/Components/PartialComponents/TextInput/TextInput.razor
+++ b/Plot/Components/PartialComponents/TextInput/TextInput.razor
@@ -39,7 +39,9 @@
     [Parameter] public bool? LabelOnTop { get; set; } = true;
 
     // This is used for JS interop
-    private DotNetObjectReference<TextInput> DotNetHelper;
+    /* Danielle Smith 3/15/2025
+    make DotNetHelper nullable to fix e2e warning */
+    private DotNetObjectReference<TextInput>? DotNetHelper;
 
     /* Danielle Smith 3/15/2025
     this method ensures that value updates to the properly binded 

--- a/Plot/Components/PartialComponents/TextInput/TextInput.razor
+++ b/Plot/Components/PartialComponents/TextInput/TextInput.razor
@@ -1,8 +1,11 @@
+@* Originally by Luke Wollenweber  *@
 @inject IJSRuntime JSRuntime
 
 <script>
-    function handleValueChanged(element)
+    function handleValueChanged(element, dotNetHelper)
     { 
+         // Call the Blazor method to update the value
+        dotNetHelper.invokeMethodAsync('OnValueChanged', element.value);
         if (element.value.trim().length < 1)
         {
             element.style.color = 'red';
@@ -17,14 +20,54 @@
 
 <div class="text-input-container @(LabelOnTop == true ? "label-top" : "label-left")">
     <label for="@Id">@Label</label>
-    <input id="@Id" type="text" value="@Value" oninput="handleValueChanged(@Id)" placeholder="@Placeholder" class="TextInput @Class" />
+    <div class="input-wrapper">
+        <!-- Text Input Field -->
+        @* Danielle Smith 3/15/2025
+        implemented new OnInputChange method to assure you can pull value back out of the TextInput *@
+        <input id="@Id" type="@Type" value="@Value" @oninput="OnInputChange" placeholder="@Placeholder" class="TextInput @Class" />
+    </div>
 </div>
 
 @code {
     [Parameter] public string? Label { get; set; } = "Enter text";
+    [Parameter] public string? Type { get; set; } = "password"; // Default type for password
     [Parameter] public string? Placeholder { get; set; } = "Type here...";
-    [Parameter] public string? Value { get; set; } = "";
+    [Parameter] public string? Value { get; set; }
+    [Parameter] public EventCallback<string> ValueChanged { get; set; }  // Event callback for ValueChanged
     [Parameter] public string? Id { get; set; }
     [Parameter] public string? Class { get; set; }
     [Parameter] public bool? LabelOnTop { get; set; } = true;
+
+    // This is used for JS interop
+    private DotNetObjectReference<TextInput> DotNetHelper;
+
+     // This method will be called via JS interop
+    [JSInvokable]
+    public async Task OnValueChanged(string newValue)
+    {
+        Value = newValue;
+        await ValueChanged.InvokeAsync(Value); // Notify the parent component about the change
+    }
+
+    // Dispose DotNetHelper when the component is disposed
+    public void Dispose()
+    {
+        DotNetHelper?.Dispose();
+    }
+
+    /* Danielle Smith 3/15/2025
+    this method ensures that value updates to the properly binded 
+    value so you can pull it back out of the TextInput */
+    private async Task OnInputChange(ChangeEventArgs e)
+    {
+        Value = e.Value?.ToString() ?? "";
+        await ValueChanged.InvokeAsync(Value);
+    }
+
+
+    // Component initialization
+    protected override void OnInitialized()
+    {
+        DotNetHelper = DotNetObjectReference.Create(this);
+    }
 }

--- a/Plot/Components/PartialComponents/TextInput/TextInput.razor
+++ b/Plot/Components/PartialComponents/TextInput/TextInput.razor
@@ -1,4 +1,4 @@
-@* Originally by Luke Wollenweber  *@
+@* Originally by Luke Wollenweber *@
 @inject IJSRuntime JSRuntime
 
 <script>
@@ -41,6 +41,15 @@
     // This is used for JS interop
     private DotNetObjectReference<TextInput> DotNetHelper;
 
+    /* Danielle Smith 3/15/2025
+    this method ensures that value updates to the properly binded 
+    value so you can pull it back out of the TextInput */
+    private async Task OnInputChange(ChangeEventArgs e)
+    {
+        Value = e.Value?.ToString() ?? "";
+        await ValueChanged.InvokeAsync(Value);
+    }
+    
      // This method will be called via JS interop
     [JSInvokable]
     public async Task OnValueChanged(string newValue)
@@ -55,9 +64,6 @@
         DotNetHelper?.Dispose();
     }
 
-    /* Danielle Smith 3/15/2025
-    this method ensures that value updates to the properly binded 
-    value so you can pull it back out of the TextInput */
     private async Task OnInputChange(ChangeEventArgs e)
     {
         Value = e.Value?.ToString() ?? "";


### PR DESCRIPTION
It should be noted that updates I did not comment as being done by me were done by @ldwollen. Here is a brief list of the things that I did:
- changed how values are being binded for text input to better assure that the parent pages can pull the value back out
- changed the test file for the text input to show the new value binding
- removed unnecessary method
- removed hide password stuff for right now since we will implement it later