### PR TITLE
Set Plot.csproj PropertyGroup TreatWarningsAsErrors to true

### DIFF
--- a/Plot/Plot.csproj
+++ b/Plot/Plot.csproj
@@ -7,4 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Toolbelt.Blazor.FileDropZone" Version="3.0.1" />
   </ItemGroup>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Set Plot.csproj PropertyGroup TreatWarningsAsErrors to true. The compiler should now treat warnings as errors. This will make catching warnings easier.