### PR TITLE
113-icon-remains-disabled-when-undisabling-button

### DIFF
--- a/Plot/Components/PartialComponents/Button/Button.razor
+++ b/Plot/Components/PartialComponents/Button/Button.razor
@@ -8,7 +8,11 @@ Program Purpose:
 The purpose of PLOT is to allow users to easily create, manage, 
 and allocate floorsets for Platos Closet. 
 
-Author: Josh Rodack (2/10/2025)-->
+Author: Josh Rodack (2/10/2025)
+
+Author: Andrew Miller (3/19/2025) - 
+Added code to turn off disabled icon when button is re-enabled.
+-->
 
 <!--Setting to allow dynamic elements-->
 @rendermode InteractiveServer
@@ -35,6 +39,9 @@ Author: Josh Rodack (2/10/2025)-->
     {
         disabledClass = "disabled-btn";
 
+    }
+    else{
+        disabledClass = ""; // Remove if re-enabled
     }
     <!--Button class, adds classes based on data passed icon
     via parameters


### PR DESCRIPTION
Fixed bug in Button component where disabled icon remained after setting IsDisabled to false. Icon now goes back to a regular pointer after IsDisabled is set to false.