### PR TITLE
105 fix image input - Fixed drag and drop opening Image URL bug, also fixed bug falsely triggering alert on hitting "cancel" in File Explorer, and fixed bug causing Upload image header to display over image after uploading

### DIFF
--- a/Plot/Components/Pages/StoreDashboard/StoreDashboard.razor
+++ b/Plot/Components/Pages/StoreDashboard/StoreDashboard.razor
@@ -8,7 +8,9 @@ Program Purpose:
 The purpose of PLOT is to allow users to easily create, manage, 
 and allocate floorsets for Platos Closet. 
 
-Author: Andrew Fulton (3/12/2025)  *@
+Author: Andrew Fulton (3/12/2025)
+
+*@
 
 @page "/store-dashboard"
 @inject IJSRuntime JS
@@ -60,7 +62,7 @@ Author: Andrew Fulton (3/12/2025)  *@
                 </div>
                 @* upload image for store component *@
                 <div class="modal-split-right-side">
-                    <ImageInput Label="Upload Image" Id="ExampleImageInput" width="330px" height="300px" />
+                    <ImageInput Label="Upload Image" Id="ExampleImageInputEdit" Width="330px" Height="300px" />
                 </div>
             </div>
             @* Employees section: EMPLOYEES HARD CODED *@
@@ -187,7 +189,7 @@ Author: Andrew Fulton (3/12/2025)  *@
             </div>
             @* upload image for store component *@
             <div class="modal-split-right-side">
-                <ImageInput Label="Upload Image" Id="ExampleImageInput" width="330px" height="300px" />
+                <ImageInput Label="Upload Image" Id="ExampleImageInputAdd" Width="330px" Height="300px" />
             </div>
         </div>
         @* Employees section*@

--- a/Plot/Components/Pages/TestComponents/ImageInput.test.razor
+++ b/Plot/Components/Pages/TestComponents/ImageInput.test.razor
@@ -11,7 +11,9 @@ and allocate floorsets for Platos Closet.
 Author: Danielle Smith (2/10/2025)  *@
 
 @page "/test/image-input"
+@rendermode InteractiveServer
+@inject IJSRuntime JS
 
 <PageTitle>Image Input</PageTitle>
 
-<ImageInput Label="Upload Image" Id="ExampleImageInput" width="300px" height="300px" />
+<ImageInput Label="Upload Image" Id="ExampleImageInput" Width="300px" Height="300px" />

--- a/Plot/Components/PartialComponents/ImageInput/ImageInput.razor
+++ b/Plot/Components/PartialComponents/ImageInput/ImageInput.razor
@@ -1,4 +1,5 @@
 @using Microsoft.AspNetCore.Components.Web
+@rendermode InteractiveServer
 @inject IJSRuntime JS
 
 @* Filename: ImageInput.razor
@@ -13,13 +14,20 @@ Program Purpose:
 The purpose of PLOT is to allow users to easily create, manage, 
 and allocate floorsets for Platos Closet. 
 
-Author: Danielle Smith (2/10/2025)  *@
+Author: Danielle Smith (2/10/2025)  
 
-<div class="ImageInput drag-drop-box dashed-border" id="@Id" style="width: @Width; height: @Height">
-    <h5 class="text-decoration-underline my-auto text-center">
+Author: Andrew Miller (3/22/2025) - Placed Class parameter in class attribute, set defaults for Width
+and Height, added aria to input box.
+
+Added id to upload image header in order to enable turning the display off (in imageInput.js)
+so it doesn't obscure images.
+*@
+
+<div class="ImageInput drag-drop-box dashed-border" id="@Id" style="width: @(Width ?? "100%"); height: @(Height ?? "100%")">
+    <h5 id="@($"{Id}-header")" class="text-decoration-underline my-auto text-center">
         <i class="fa-solid fa-image"></i> @Label
     </h5>
-    <input type="file" id="@($"{Id}-fileInput")" class="d-none" onchange="onImageSelected(event, '@Id')">
+    <input type="file" id="@($"{Id}-fileInput")" class="d-none @Class" onchange="onImageSelected(event, '@Id')" aria-label="@Label">
 </div>
 
 @code {

--- a/Plot/Components/PartialComponents/ImageInput/ImageInput.razor
+++ b/Plot/Components/PartialComponents/ImageInput/ImageInput.razor
@@ -19,12 +19,10 @@ Author: Danielle Smith (2/10/2025)
 Author: Andrew Miller (3/22/2025) - Placed Class parameter in class attribute, set defaults for Width
 and Height, added aria to input box.
 
-Added id to upload image header in order to enable turning the display off (in imageInput.js)
-so it doesn't obscure images.
 *@
 
 <div class="ImageInput drag-drop-box dashed-border" id="@Id" style="width: @(Width ?? "100%"); height: @(Height ?? "100%")">
-    <h5 id="@($"{Id}-header")" class="text-decoration-underline my-auto text-center">
+    <h5 class="text-decoration-underline my-auto text-center">
         <i class="fa-solid fa-image"></i> @Label
     </h5>
     <input type="file" id="@($"{Id}-fileInput")" class="d-none @Class" onchange="onImageSelected(event, '@Id')" aria-label="@Label">

--- a/Plot/wwwroot/js/global.js
+++ b/Plot/wwwroot/js/global.js
@@ -1,6 +1,11 @@
 // Danielle Smith - 3/10/2025
 // When a dropdown is loaded, call a global JS function 
 // to initialize it properly with Bootstrap
+
+// Andrew Miller - 3/22/2025
+// Added listeners to document to prevent drop
+// and dragover events from going to image URLs.
+
 window.reinitializeDropdownById = (dropdownId) => {
     // get the element by it's ID
     let el = document.getElementById(dropdownId);
@@ -28,3 +33,14 @@ window.reinitializeDropdownById = (dropdownId) => {
         newDropdown.toggle();
     });
 };
+
+// Prevent the default behavior when an image is dropped anywhere on the document
+// Stops image URLs from opening in new tabs when the image lands outside the drop
+// area
+document.addEventListener("dragover", (event) => {
+    event.preventDefault();
+});
+
+document.addEventListener("drop", (event) => {
+    event.preventDefault();
+});

--- a/Plot/wwwroot/js/global.js
+++ b/Plot/wwwroot/js/global.js
@@ -33,14 +33,3 @@ window.reinitializeDropdownById = (dropdownId) => {
         newDropdown.toggle();
     });
 };
-
-// Prevent the default behavior when an image is dropped anywhere on the document
-// Stops image URLs from opening in new tabs when the image lands outside the drop
-// area
-document.addEventListener("dragover", (event) => {
-    event.preventDefault();
-});
-
-document.addEventListener("drop", (event) => {
-    event.preventDefault();
-});

--- a/Plot/wwwroot/js/imageInput.js
+++ b/Plot/wwwroot/js/imageInput.js
@@ -8,9 +8,6 @@
    This prevents a false "Please upload an image file"
    alert if you click on "Cancel" in File Explorer. 
    
-   Added line to make display of upload image header none
-   after uploading image so the label doesn't go over the image.
-
 */
 window.initializeImageInput = (id) => {
     // get the drag/drop area as well as the file input
@@ -52,10 +49,6 @@ window.initializeImageInput = (id) => {
 function onImageSelected(event, id) {
     const file = event.target.files[0];
 
-    // Represents image header. Keep argument in agreement with
-    // the same from the ImageInput custom component
-    let uploadImageHeader = document.getElementById(`${id}-header`);
-
     if(!file){  // cancel button in file explorer returns an empty file object
         return;
     }
@@ -70,8 +63,6 @@ function onImageSelected(event, id) {
         dropArea.style.backgroundPosition = "center";
         dropArea.classList.remove("dashed-border");
 
-        // Place upload image header behind image
-        uploadImageHeader.style.display = "none";
         };
         
         reader.readAsDataURL(file);

--- a/Plot/wwwroot/js/imageInput.js
+++ b/Plot/wwwroot/js/imageInput.js
@@ -1,3 +1,20 @@
+/* File Purpose: Global JS file for ImageInput custom component
+   which serves the purpose of enabling image uploads.
+
+   Author: Andrew Miller (3/22/2025)
+   File already written but no previous author given. 
+   
+   Added check for empty file to OnImageSelected function.
+   This prevents a false "Please upload an image file"
+   alert if you click on "Cancel" in File Explorer. 
+   
+   Added line to make display of upload image header none
+   after uploading image so the label doesn't go over the image.
+   
+   Added event listeners for dragover and drop to document
+   to prevent image url from opening in new tab.
+
+*/
 window.initializeImageInput = (id) => {
     // get the drag/drop area as well as the file input
     const dropArea = document.getElementById(`${id}`);
@@ -30,6 +47,18 @@ window.initializeImageInput = (id) => {
             fileInput.dispatchEvent(new Event("change"));
         }
     });
+
+    // Prevent the default behavior when an image is dropped anywhere on the document
+    // Stops image URLs from opening in new tabs when the image lands outside the drop
+    // area
+    document.addEventListener("dragover", (event) => {
+        event.preventDefault();
+    });
+
+    document.addEventListener("drop", (event) => {
+        event.preventDefault();
+    });
+    
 }
 
 // if a valid image file was selected, change the background 
@@ -37,16 +66,28 @@ window.initializeImageInput = (id) => {
 function onImageSelected(event, id) {
     const file = event.target.files[0];
 
+    // Represents image header. Keep argument in agreement with
+    // the same from the ImageInput custom component
+    let uploadImageHeader = document.getElementById(`${id}-header`);
+
+    if(!file){  // cancel button in file explorer returns an empty file object
+        return;
+    }
+
     if (file && file.type.startsWith("image/")) {
         const reader = new FileReader();
         reader.onload = function (e) {
-            let dropArea = document.getElementById(`${id}`);
+        let dropArea = document.getElementById(`${id}`);
 
-            dropArea.style.backgroundImage = `url(${e.target.result})`;
-            dropArea.style.backgroundSize = "cover";
-            dropArea.style.backgroundPosition = "center";
-            dropArea.classList.remove("dashed-border");
+        dropArea.style.backgroundImage = `url(${e.target.result})`;
+        dropArea.style.backgroundSize = "cover";
+        dropArea.style.backgroundPosition = "center";
+        dropArea.classList.remove("dashed-border");
+
+        // Place upload image header behind image
+        uploadImageHeader.style.display = "none";
         };
+        
         reader.readAsDataURL(file);
     } else {
         alert("Please upload a valid image file.");

--- a/Plot/wwwroot/js/imageInput.js
+++ b/Plot/wwwroot/js/imageInput.js
@@ -10,9 +10,6 @@
    
    Added line to make display of upload image header none
    after uploading image so the label doesn't go over the image.
-   
-   Added event listeners for dragover and drop to document
-   to prevent image url from opening in new tab.
 
 */
 window.initializeImageInput = (id) => {
@@ -48,17 +45,6 @@ window.initializeImageInput = (id) => {
         }
     });
 
-    // Prevent the default behavior when an image is dropped anywhere on the document
-    // Stops image URLs from opening in new tabs when the image lands outside the drop
-    // area
-    document.addEventListener("dragover", (event) => {
-        event.preventDefault();
-    });
-
-    document.addEventListener("drop", (event) => {
-        event.preventDefault();
-    });
-    
 }
 
 // if a valid image file was selected, change the background 


### PR DESCRIPTION
Drag and drop to the drop area didn't open new tab for me, but dropping it outside the drop area did. Fixed that in global.js with document listeners for drop and dragover events to prevent defaults.

Clicking cancel in File Explorer triggered the "Please upload a valid image file" so I added a check for empty file in onImageSelected to fix that.

Upload image header was displaying over images passed into the ImageInput component, so I gave it a dynamic id in the custom component and set it so the display would set to none when a valid image was uploaded.