### PR TITLE
Multiple and AllowEmpty parameters added as Parameters to OptionInput

### DIFF
--- a/Plot/Components/Pages/TestComponents/OptionInput.test.razor
+++ b/Plot/Components/Pages/TestComponents/OptionInput.test.razor
@@ -14,6 +14,15 @@
     <h5>Option to display displays here when selected:</h5>
     <p>@optionInput3Output</p>
 </div>
+<OptionInput ID="optionInput4" Class="optionInput" label="Multiple Options"
+    optionsText="@(new List<String> { "Option 1", "Option 2", "Option 3"})"
+    optionsValues="@(new List<String> { "Option 1", "Option 2", "Option 3"})"
+    Multiple />
+
+<OptionInput ID="optionInput5" Class="optionInput" label="Empty Option Input enabled by Allow Empty"
+    optionsText="@(new List<String>())"
+    optionsValues="@(new List<String>())"
+    AllowEmpty />
 
 @code{
     // Bound variable for displaying output of optionInput3

--- a/Plot/Components/PartialComponents/OptionInput/OptionInput.razor
+++ b/Plot/Components/PartialComponents/OptionInput/OptionInput.razor
@@ -9,6 +9,12 @@ when an option is selected. Adapted OnSelectFunc method to check
 if a method is specified and handle asynchronous methods
 with InvokeAsync. Passes value in option as argument string 
 to specified method.
+
+3/29/2025
+Added Multiple and AllowEmpty parameters.
+
+Added error handling to prevent OnSelectFunction usage
+with Multiple parameter as true
 *@
 <div class="OptionInput @Class" id="@ID">
     <h5 class="row">
@@ -25,7 +31,7 @@ to specified method.
         {
             @((MarkupString)_blankIcon)
         } @* "(e) => OnSelectFunction.InvokeAsync(e.Value?.ToString())" *@
-        <select class="col-md-11" @onchange="OnSelectFunc">
+        <select class="col-md-11" @onchange="OnSelectFunc" multiple="@Multiple">
             @for (var i = 0; i < optionsValues.Count; i++)
             {
                 <option value=@optionsValues[i]>@optionsText[i]</option>
@@ -65,9 +71,20 @@ to specified method.
 
     [Parameter]
     // Specifies method ran when selecting an option
+    // Returns e.Value as a string
+    // Only works for SINGLE-value selection
     public EventCallback<string> OnSelectFunction {get; set;}
 
-    //Validate that the option list has valid arguments: more than 0 entries, and matching number of display and value entries.
+    [Parameter]
+    // Allow empty select option - False by default
+    public bool AllowEmpty {get; set;} = false;
+
+    [Parameter]
+    // Is this Multiple? False (Single) by default
+    public bool Multiple {get; set;} = false;
+
+    //Validate that the option list has valid arguments: more than 0 entries(unless AllowEmpty is true), 
+    // and matching number of display and value entries.
     protected override async Task OnParametersSetAsync(){
         await base.OnParametersSetAsync();
 
@@ -79,7 +96,7 @@ to specified method.
         {
             throw new ArgumentNullException("Options text list was not initialized: Did you add entries?");
         }
-        if(optionsValues.Count == 0 || optionsText.Count == 0)
+        if( (optionsValues.Count == 0 || optionsText.Count == 0) & !AllowEmpty)
         {
             throw new ArgumentException(String.Format("Cannot have zero entries in values (length {0}) or text (length {1}) lists.",optionsValues.Count, optionsText.Count));
         }
@@ -87,7 +104,9 @@ to specified method.
         {
             throw new ArgumentException(String.Format("Option values count, {0}, does not match options text count, {1}.",optionsValues.Count, optionsText.Count));
         }
-        
+        if(Multiple & OnSelectFunction.HasDelegate){
+            throw new ArgumentException(String.Format("The OnSelectFunction parameter may not used in conjunction with the Multiple parameter set to true"));
+        }
     }
 
     //When option is selected this
@@ -104,5 +123,4 @@ to specified method.
             await OnSelectFunction.InvokeAsync(e.Value?.ToString());
         }
     }
-    
 }


### PR DESCRIPTION
Needed as part of updating the User Dashboard interface to handle adding multiple stores. Both added to examples in test component.

Since OnSelectFunction invokes string arguments and is not suitable for Multiple selections, error handling added to check that OnSelectFunction is not defined if Multiple flag is used.