### PR TITLE
Frontend Piece handles Copy dropdown click

### DIFF
--- a/Plot/Components/Pages/FloorsetDashboard/FloorsetDashboard.razor
+++ b/Plot/Components/Pages/FloorsetDashboard/FloorsetDashboard.razor
@@ -179,17 +179,16 @@ Author: Andrew Fulton (3/13/2025)  *@
 
     private async Task OnCopyFloorsetClick(Data.Models.Floorsets.Floorset Floorset)
     {
-        Data.Models.Floorsets.CreateFloorset createFloorset = new Data.Models.Floorsets.CreateFloorset
-        {
-            NAME = Floorset.NAME,
-            CREATED_BY = -1,
-            DATE_CREATED = DateTime.Now,
-            DATE_MODIFIED = DateTime.Now,
-            MODIFIED_BY = -1,
-            STORE_TUID = StoreId
-        };
+        // Handles Copy click
 
-        await FloorsetsHttpClient.CreateFloorset(createFloorset);
+        // Create new FloorsetRef to just pass on TUID
+        Data.Models.Floorsets.FloorsetRef FloorsetRef = new();
+        FloorsetRef.TUID = Floorset.TUID;
+
+        // Call Client to send copy floorset request
+        await FloorsetsHttpClient.CopyFloorset(FloorsetRef);
         await UpdateFloorsets();
+
+        StateHasChanged();
     }
 }

--- a/Plot/Data/Models/Floorsets/FloorsetRef.cs
+++ b/Plot/Data/Models/Floorsets/FloorsetRef.cs
@@ -1,0 +1,24 @@
+/*
+    Filename: FloorsetRef.cs
+    Part of Project: PLOT/PLOT-BE/Plot/Data/Models/Floorset
+    and PLOT/PLOT-FE/Plot/Data/Models/Floorset
+
+    File Purpose:
+    This file references the Floorset with just the TUID
+    
+    Class Purpose:
+    This record is used to pass just the TUID to the database
+    for cases where only the TUID is needed.
+
+    Written by: Andrew Miller (4/24/2025)
+*/
+
+using System.ComponentModel.DataAnnotations;
+
+namespace Plot.Data.Models.Floorsets;
+
+public class FloorsetRef
+{
+    [Required]
+    public int TUID { get; set; }
+}

--- a/Plot/Services/FloorsetsHttpClient.cs
+++ b/Plot/Services/FloorsetsHttpClient.cs
@@ -42,4 +42,13 @@ public class FloorsetsHttpClient : PlotHttpClient
     {
         return await SendDeleteAsync($"/{floorsetId}");
     }
+
+    public async Task<HttpStatusCode> CopyFloorset(FloorsetRef FloorsetRef)
+    {   
+        JsonContent body = JsonContent.Create(FloorsetRef);
+
+        var (status, response) = await SendPostAsync<HttpStatusCode>($"/copy-floorset", body);
+
+        return response;
+    }
 }


### PR DESCRIPTION
This is the frontend branch and works along with 38-copy-floorset-be and 127-copy-floorset-db.

Handles Copy dropdown click and makes a request to backend to copy the floorset. Successfully adds floorset to the dashboard with everything including fixtures, floorsets, and allocation data fully copied.