### PR TITLE
Adding image compression/resizing to fixture and store images

### DIFF
--- a/Plot/Components/Layout/MainLayout.razor
+++ b/Plot/Components/Layout/MainLayout.razor
@@ -17,6 +17,7 @@
 
     @* imageinput js *@
     <script src="js/imageInput.js"></script>
+    <script src="js/compressImage.js"></script>
 </head>
 
 <body>

--- a/Plot/Components/Pages/FloorsetEditor/AddUpdateFixtureModalBody.razor
+++ b/Plot/Components/Pages/FloorsetEditor/AddUpdateFixtureModalBody.razor
@@ -1,6 +1,6 @@
 @* Danielle Smith - 4/21/2025 *@
 @inject FixturesHttpClient FixturesHttpClient
-
+@inject IJSRuntime Runtime
 @using Plot.Data.Models.Fixtures
 
 <ModalBody>
@@ -61,11 +61,26 @@
 
     private async Task OnImageUpload(InputFileChangeEventArgs e)
     {
-        MemoryStream ms = new MemoryStream();
-        await e.File.OpenReadStream().CopyToAsync(ms);
-        var bytes = ms.ToArray();
+        try {
+            await Task.Run(() => Console.WriteLine("Upload Image"));
+            var file = e.File;
+            using var stream = file.OpenReadStream(file.Size);
+            using var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
+            var originalImageBytes = memoryStream.ToArray();
+            await Task.Run(() => Console.WriteLine("Original image bytes:" + originalImageBytes.Length));
+            var compressedImageBytes = await Runtime.InvokeAsync<byte[]>("compressImage", originalImageBytes, 300, 300, 1);
+            await Task.Run(() => Console.WriteLine("Compressed image bytes:" + compressedImageBytes.Length));
 
-        AddUpdateFixtureModel!.ICON = bytes;
+            if (AddUpdateFixtureModel != null)
+            {
+                AddUpdateFixtureModel.ICON = compressedImageBytes;
+            }
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine("Image uploading/compressing error: " + exception);
+        }
     }
 
     public void HandleLengthChange(ChangeEventArgs e)

--- a/Plot/Components/Pages/FloorsetEditor/FloorsetEditor.razor
+++ b/Plot/Components/Pages/FloorsetEditor/FloorsetEditor.razor
@@ -44,6 +44,8 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
 <script src="js/copyFloorsetCard.js"></script>
 <script src="js/floorsetEditor.js"></script>
+<script src="js/compressImage.js"></script>
+
 <FloorsetCanvas FloorsetId="FloorsetId" />
 
 @* Sidebar *@

--- a/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
+++ b/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
@@ -1,5 +1,6 @@
 @inject UsersHttpClient UsersHttpClient
 @inject StoresHttpClient StoresHttpClient
+@inject IJSRuntime Runtime
 
 @using Plot.Data.Models.Users
 
@@ -136,14 +137,27 @@
 
     private async Task OnImageUpload(InputFileChangeEventArgs e)
     {
-        await Task.Run(() => Console.WriteLine("Upload Image"));
-        MemoryStream ms = new MemoryStream();
-        await e.File.OpenReadStream().CopyToAsync(ms);
-        var bytes = ms.ToArray();
+        try {
+            await Task.Run(() => Console.WriteLine("Upload Image"));
+            var file = e.File;
+            using var stream = file.OpenReadStream(file.Size);
+            using var memoryStream = new MemoryStream();
+            await stream.CopyToAsync(memoryStream);
 
-        if (AddUpdateStoreModel != null)
+            var originalImageBytes = memoryStream.ToArray();
+
+            await Task.Run(() => Console.WriteLine("Original image bytes:" + originalImageBytes.Length));
+            var compressedImageBytes = await Runtime.InvokeAsync<byte[]>("compressImage", originalImageBytes, 480, 360, 1);
+
+            await Task.Run(() => Console.WriteLine("Original image bytes:" + compressedImageBytes.Length));
+            if (AddUpdateStoreModel != null)
+            {
+                AddUpdateStoreModel.BLUEPRINT_IMAGE = compressedImageBytes;
+            }
+        }
+        catch (Exception exception)
         {
-            AddUpdateStoreModel!.BLUEPRINT_IMAGE = bytes;
+            Console.WriteLine("Image uploading/compressing error: " + exception);
         }
     }
 }

--- a/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
+++ b/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
@@ -143,13 +143,11 @@
             using var stream = file.OpenReadStream(file.Size);
             using var memoryStream = new MemoryStream();
             await stream.CopyToAsync(memoryStream);
-
             var originalImageBytes = memoryStream.ToArray();
-
             await Task.Run(() => Console.WriteLine("Original image bytes:" + originalImageBytes.Length));
             var compressedImageBytes = await Runtime.InvokeAsync<byte[]>("compressImage", originalImageBytes, 480, 360, 1);
-
             await Task.Run(() => Console.WriteLine("Compressed image bytes:" + compressedImageBytes.Length));
+            
             if (AddUpdateStoreModel != null)
             {
                 AddUpdateStoreModel.BLUEPRINT_IMAGE = compressedImageBytes;

--- a/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
+++ b/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
@@ -149,7 +149,7 @@
             await Task.Run(() => Console.WriteLine("Original image bytes:" + originalImageBytes.Length));
             var compressedImageBytes = await Runtime.InvokeAsync<byte[]>("compressImage", originalImageBytes, 480, 360, 1);
 
-            await Task.Run(() => Console.WriteLine("Original image bytes:" + compressedImageBytes.Length));
+            await Task.Run(() => Console.WriteLine("Compressed image bytes:" + compressedImageBytes.Length));
             if (AddUpdateStoreModel != null)
             {
                 AddUpdateStoreModel.BLUEPRINT_IMAGE = compressedImageBytes;

--- a/Plot/Program.cs
+++ b/Plot/Program.cs
@@ -113,13 +113,16 @@ builder.Services.AddAuthorizationBuilder()
 
 builder.Services.AddCascadingAuthenticationState();
 
-
 builder.Services.AddAuthorizationCore();
 builder.Services.AddHttpContextAccessor();
 builder.Services.AddServerSideBlazor().AddCircuitOptions(options =>
 {
     options.DetailedErrors = true;
-});
+})
+.AddHubOptions(options =>
+{
+    options.MaximumReceiveMessageSize = 1 * 1024 * 1024;
+});;
 
 var MyAllowSpecificOrigins = "_myAllowSpecificOrigins";
 

--- a/Plot/wwwroot/js/compressImage.js
+++ b/Plot/wwwroot/js/compressImage.js
@@ -1,3 +1,18 @@
+/*
+    Filename: compressImage.js
+    Part of Project: PLOT/PLOT-FE/Plot/wwwroot/js
+
+    File Purpose:
+    This file contains an image compression implementation for
+    the image uploading functionality. This will take the user's
+    image as a byte array, print it onto a js canvas with a 
+    specified quality, then crop the image down to a specified
+    target width/height. Found this to be the easiest way to
+    have the image inputs be around the same size and manageable.
+
+    Written by: Jordan Houlihan
+*/
+
 window.compressImage = async function (
   byteArray,
   targetWidth,

--- a/Plot/wwwroot/js/compressImage.js
+++ b/Plot/wwwroot/js/compressImage.js
@@ -1,0 +1,61 @@
+window.compressImage = async function (
+  byteArray,
+  targetWidth,
+  targetHeight,
+  quality
+) {
+  const blob = new Blob([new Uint8Array(byteArray)], { type: "image/jpeg" });
+  const img = new Image();
+
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(blob);
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = targetWidth;
+      canvas.height = targetHeight;
+      const ctx = canvas.getContext("2d");
+
+      const imageRatio = img.width / img.height;
+      const targetRatio = targetWidth / targetHeight;
+
+      let sourceWidth, sourceHeight, sourceX, sourceY;
+
+      if (imageRatio > targetRatio) {
+        sourceHeight = img.height;
+        sourceWidth = img.height * targetRatio;
+        sourceX = (img.width - sourceWidth) / 2;
+        sourceY = 0;
+      } else {
+        sourceWidth = img.width;
+        sourceHeight = img.width / targetRatio;
+        sourceX = 0;
+        sourceY = (img.height - sourceHeight) / 2;
+      }
+
+      ctx.drawImage(
+        img,
+        sourceX,
+        sourceY,
+        sourceWidth,
+        sourceHeight,
+        0,
+        0,
+        targetWidth,
+        targetHeight
+      );
+
+      canvas.toBlob(
+        (compressedBlob) => {
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            resolve(new Uint8Array(reader.result));
+          };
+          reader.readAsArrayBuffer(compressedBlob);
+        },
+        "image/jpeg",
+        quality
+      );
+    };
+    img.src = url;
+  });
+};


### PR DESCRIPTION
This will take the image upload from the user and crop the image down to be 480x360px. This will make the images ~20KB. The only thing to know when testing this is that the frontend doesn't yet have a loader shown for when an imaging is in progress for being uploaded, so you'll have to wait a couple seconds for the image to fully load into the program before trying to add the store/fixture. I added console.writeline() as a mental marker to see the progress in the image upload (for small images it's usually pretty close to instant, for large images >10MB it takes a couple seconds).