### PR TITLE
306 employees are addedremoved without hitting save - Plus AltText property added to CardImage and Store Dashboard set to have name in alt property

### DIFF
--- a/Plot/Components/Pages/StoreDashboard/AddStoreModal.razor
+++ b/Plot/Components/Pages/StoreDashboard/AddStoreModal.razor
@@ -49,6 +49,9 @@
     /// </summary>
     public int StoreId = -1;
 
+    /// <summary>
+    /// Empty ImageSrc, passed to ImageInput within AddUpdateStoreModalBody as parameter
+    /// </summary>
     private string ImageSrc = "";
 
     /// <summary>
@@ -73,7 +76,7 @@
                     foreach (var addedUser in addedUsers)
                     {
                         var success = Users.TryAdd(addedUser.TUID, addedUser);
-                        await InvokeAsync(StateHasChanged);
+                        await InvokeAsync(StateHasChanged); // Needed to add employees
                     }
                 }
             }
@@ -164,11 +167,14 @@
             ToastService.ShowSuccess("The store was created.");
         }
 
+        // Clear Add Store Model
         await ClearAddStoreModel();
     }
 
     /// <summary>
     /// removes all of the values from the AddStoreModel
+    /// resets length and width to 1, clears Users
+    /// and invokes StateHasChanged
     /// (Clears the form for the next store)
     /// </summary>
     /// <param name=""> no parameters taken </param>

--- a/Plot/Components/Pages/StoreDashboard/AddStoreModal.razor
+++ b/Plot/Components/Pages/StoreDashboard/AddStoreModal.razor
@@ -11,7 +11,7 @@
         <AddUpdateStoreModalBody AddUpdateStoreModel="AddStoreModel" StoreId="StoreId"
             AddEmployeeTarget="#create-store-add-employee" Users="Users.Values.ToList()" DeleteUser="DeleteUser" />
 
-        <ModalFooter OnCancelClick="ClearAddStoreModel">
+        <ModalFooter OnCancelClick="async () => await ClearAddStoreModel()">
             <Button Class="Button" TextAlignment="center" Variant="primary" type="submit" data-bs-dismiss="modal">
                 Create Store
             </Button>
@@ -20,7 +20,7 @@
 </Modal>
 
 <AddEmployeeToStoreModal id="create-store-add-employee" AddEmployeeTarget="#create-store"
-    OnAddEmployeesSubmit="OnAddEmployeesSubmit" />
+    OnAddEmployeesSubmit="OnAddEmployeesSubmit" ImageSrc="ImageSrc"/>
 
 @code {
     /// <summary>
@@ -41,13 +41,15 @@
     /// <summary>
     /// Holds all of the users that are/will be associated with a store
     /// </summary>
-    private Dictionary<int, Data.Models.Users.UserDTO> Users = new Dictionary<int, Data.Models.Users.UserDTO>();
+    public Dictionary<int, Data.Models.Users.UserDTO> Users = new Dictionary<int, Data.Models.Users.UserDTO>();
 
     /// <summary>
     /// The ID of the store currently being edited 
     /// (-1 when creating a store becasue it doesn't have a TUID yet)
     /// </summary>
     public int StoreId = -1;
+
+    private string ImageSrc = "";
 
     /// <summary>
     /// Updates the Users Dictionary to include all of the employees that should 
@@ -68,10 +70,11 @@
 
                 if (addedUsers != null)
                 {
-                    addedUsers.ForEach((addedUser) =>
+                    foreach (var addedUser in addedUsers)
                     {
-                        Users.TryAdd(addedUser.TUID, addedUser);
-                    });
+                        var success = Users.TryAdd(addedUser.TUID, addedUser);
+                        await InvokeAsync(StateHasChanged);
+                    }
                 }
             }
         }
@@ -100,6 +103,8 @@
             LENGTH = 1,
             WIDTH = 1,
         };
+
+        _ = ImageSrc; // To prevent a not used error (it is used in child components but that doesn't satisfy the compiler)
     }
 
     /// <summary>
@@ -117,6 +122,8 @@
         AddStoreModel!.USER_TUIDS = joinedEmployees;
 
         await UpdateUsers();
+
+        StateHasChanged();
     }
 
     /// <summary>
@@ -157,7 +164,7 @@
             ToastService.ShowSuccess("The store was created.");
         }
 
-        ClearAddStoreModel();
+        await ClearAddStoreModel();
     }
 
     /// <summary>
@@ -166,8 +173,16 @@
     /// </summary>
     /// <param name=""> no parameters taken </param>
     /// <returns> void </returns>
-    private void ClearAddStoreModel()
+    private async Task ClearAddStoreModel()
     {
-        AddStoreModel = new();
+        AddStoreModel = new()
+        {
+            LENGTH = 1,
+            WIDTH = 1,
+        };
+
+        Users.Clear();
+
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
+++ b/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
@@ -145,6 +145,7 @@
     /// <summary>
     /// Holds the base64 of an image for the store BP.
     /// The ImageInput component in the modal is set to this string (This displays the image in the modal)
+    /// Optional parameter, passed in from parent component as parameter
     /// </summary>
     [Parameter] public string? ImageSrc { get; set; }
 

--- a/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
+++ b/Plot/Components/Pages/StoreDashboard/AddUpdateStoreModalBody.razor
@@ -87,9 +87,12 @@
                 <p class="circle-name">Add Employee</p>
             </div>
 
-            @foreach (var User in Users.Skip(1).ToList())
-            {
-                if (User != null && User.FIRST_NAME != null && User.LAST_NAME != null)
+            @foreach (var User in Users.ToList())
+            {   // Andrew Miller (4/27/2025): Puts employees on Add or Edit Store Modal.
+                // To exclude the Root user, checks that User.TUID is not 0
+                // Previously Users.Skip(1).ToList() was used. That caused a bug where
+                // the Add Store Modal skipped over the first employee added
+                if (User != null && User.FIRST_NAME != null && User.LAST_NAME != null && User.TUID != 0)
                 {
                     <div class="d-flex flex-column align-items-center">
                         <button type="button" class="btn btn-secondary btn-circle position-relative"
@@ -143,7 +146,7 @@
     /// Holds the base64 of an image for the store BP.
     /// The ImageInput component in the modal is set to this string (This displays the image in the modal)
     /// </summary>
-    private string ImageSrc = "";
+    [Parameter] public string? ImageSrc { get; set; }
 
     /// <summary>
     /// When the modal is initialized, set the imageinput component to show the
@@ -153,10 +156,12 @@
     /// <returns> void </returns>
     protected override void OnInitialized()
     {
+        /*
         if (AddUpdateStoreModel == null) return;
 
         ImageSrc = AddUpdateStoreModel.BLUEPRINT_IMAGE != null ?
         $"data:image/jpeg;base64,{Convert.ToBase64String(AddUpdateStoreModel.BLUEPRINT_IMAGE)}" : "";
+        */
     }
 
     /// <summary>

--- a/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
+++ b/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
@@ -1,6 +1,7 @@
 @inject StoresHttpClient StoresHttpClient
 @inject UsersHttpClient UsersHttpClient
 @inject ToastService ToastService
+@inject IJSRuntime JS
 
 @using Plot.Services
 
@@ -21,6 +22,18 @@
 
 <AddEmployeeToStoreModal id="@($"add-employee-{Store.TUID}")" AddEmployeeTarget="@($"#edit-store-{Store.TUID}")"
     OnAddEmployeesSubmit="OnAddEmployeesSubmit" ImageSrc="ImageSrc"/>
+
+<script>
+    function setBackgroundImage(StoreId, ImageSrc) {
+        console.log("set background image");
+        let image_input = document.getElementById(StoreId + "-container");
+        image_input.style.backgroundImage = `url(${ImageSrc})`;
+        image_input.style.backgroundSize = "cover";
+        image_input.style.backgroundPosition = "center";
+
+    }
+</script>
+
 
 @code {
     /// <summary>
@@ -60,6 +73,24 @@
     private string? EmployeesAtStart;
 
     private string? ImageSrc;
+
+    /// <TODO>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {   
+        if(firstRender){
+            ImageSrc = EditStoreModel!.BLUEPRINT_IMAGE != null
+            ? $"data:image/jpeg;base64,{Convert.ToBase64String(EditStoreModel!.BLUEPRINT_IMAGE)}" : "";
+
+            if (!string.IsNullOrEmpty(ImageSrc))
+            {
+                // Ensure that storeId is correctly passed in
+                await JS.InvokeVoidAsync("setBackgroundImage", StoreId, ImageSrc);
+                Console.WriteLine("Exiting the asynchronous invocation of the setBackgroundImage method");
+            }
+
+            Console.WriteLine(EditStoreModel.BLUEPRINT_IMAGE);
+        }
+    }
 
     /// <summary>
     /// Updates the Users Dictionary to include all of the employees that should 
@@ -132,10 +163,6 @@
             USER_TUIDS = string.Empty
         };
 
-        ImageSrc = EditStoreModel!.BLUEPRINT_IMAGE != null ?
-        $"data:image/jpeg;base64,{Convert.ToBase64String(EditStoreModel!.BLUEPRINT_IMAGE)}" : "";
-
-        Console.WriteLine(EditStoreModel.BLUEPRINT_IMAGE);
 
     }
 

--- a/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
+++ b/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
@@ -21,16 +21,18 @@
 </Modal>
 
 <AddEmployeeToStoreModal id="@($"add-employee-{Store.TUID}")" AddEmployeeTarget="@($"#edit-store-{Store.TUID}")"
-    OnAddEmployeesSubmit="OnAddEmployeesSubmit" ImageSrc="ImageSrc"/>
+    OnAddEmployeesSubmit="OnAddEmployeesSubmit" ImageSrc="ImageSrc" />
 
 <script>
+    // Sets background image - For initialization
+    // OnImageUpload (in AddUpdateStoreModalBody.razor) doesn't set image on initialization
+    // only when the user uploads the image
     function setBackgroundImage(StoreId, ImageSrc) {
         console.log("set background image");
         let image_input = document.getElementById(StoreId + "-container");
         image_input.style.backgroundImage = `url(${ImageSrc})`;
         image_input.style.backgroundSize = "cover";
         image_input.style.backgroundPosition = "center";
-
     }
 </script>
 
@@ -72,12 +74,19 @@
     /// </summary>
     private string? EmployeesAtStart;
 
+    /// <summary>
+    /// Holds string used for the image source, ImageSrc for the ImageInput component in AddUpdateStoreModalBody
+    /// </summary>
     private string? ImageSrc;
 
-    /// <TODO>
+    /// <summary>
+    /// OnAfterRenderAsync, asynchronous call after rendering. If this is the first render,
+    /// sets ImageSrc as the EditStoreModel's BLUEPRINT_IMAGE
+    /// </summary>
     protected override async Task OnAfterRenderAsync(bool firstRender)
-    {   
-        if(firstRender){
+    {
+        if (firstRender)
+        {
             ImageSrc = EditStoreModel!.BLUEPRINT_IMAGE != null
             ? $"data:image/jpeg;base64,{Convert.ToBase64String(EditStoreModel!.BLUEPRINT_IMAGE)}" : "";
 
@@ -87,13 +96,11 @@
                 await JS.InvokeVoidAsync("setBackgroundImage", StoreId, ImageSrc);
                 Console.WriteLine("Exiting the asynchronous invocation of the setBackgroundImage method");
             }
-
-            Console.WriteLine(EditStoreModel.BLUEPRINT_IMAGE);
         }
     }
 
     /// <summary>
-    /// Updates the Users Dictionary to include all of the employees that should 
+    /// Updates the Users Dictionary to include all of the employees that should
     /// be associated with the store
     /// </summary>
     /// <param name=""> no parameters taken </param>
@@ -124,8 +131,7 @@
                     foreach (var addedUser in addedUsers)
                     {
                         var success = Users.TryAdd(addedUser.TUID, addedUser);
-                        Console.WriteLine(addedUser.TUID);
-                        await InvokeAsync(StateHasChanged);
+                        await InvokeAsync(StateHasChanged); // Needed to add employees
                     }
                 }
             }
@@ -145,30 +151,39 @@
     /// <summary>
     /// Creates a new EditStoreModel when the modal is created.
     /// The values are filled in from the component's Store parameter
+    /// in the call to ResetEditStoreModel
     /// </summary>
     /// <param name=""> No parameters taken </param>
     /// <returns> void </returns>
     protected override void OnInitialized()
     {
-        EditStoreModel ??= new Data.Models.Stores.UpdatePublicInfoStore
-        {
-            NAME = Store.NAME!,
-            ADDRESS = Store.ADDRESS!,
-            CITY = Store.CITY!,
-            STATE = Store.STATE!,
-            ZIP = Store.ZIP!,
-            WIDTH = Store.WIDTH,
-            LENGTH = Store.LENGTH,
-            BLUEPRINT_IMAGE = Store.BLUEPRINT_IMAGE,
-            USER_TUIDS = string.Empty
-        };
+        EditStoreModel = new();
+        ResetEditStoreModel();
+    }
 
+    /// <summary>
+    /// Fills in the values of EditStoreModel from the Store
+    /// parameter. Used at initialization and also when resetting
+    /// the store
+    public void ResetEditStoreModel()
+    {
+        Console.WriteLine("Resetting edit store model");
 
+        EditStoreModel!.NAME = Store!.NAME;
+        EditStoreModel!.ADDRESS = Store!.ADDRESS;
+        EditStoreModel!.CITY = Store!.CITY;
+        EditStoreModel!.STATE = Store!.STATE;
+        EditStoreModel!.ZIP = Store!.ZIP;
+        EditStoreModel!.WIDTH = Store!.WIDTH;
+        EditStoreModel!.LENGTH = Store!.LENGTH;
+        EditStoreModel!.BLUEPRINT_IMAGE = Store!.BLUEPRINT_IMAGE;
+        EditStoreModel!.USER_TUIDS = string.Empty;
+        InvokeAsync(StateHasChanged);
     }
 
     /// <summary>
     /// populates the Users dictionary with the current employees of the store
-    ///  when the modal is initially created
+    /// when the modal is initially created
     /// </summary>
     /// <param name=""> No parameters taken </param>
     /// <returns> void </returns>
@@ -192,7 +207,6 @@
 
         EditStoreModel!.USER_TUIDS = joinedEmployees;
 
-        //await UpdateUsers();
         if (EditStoreModel != null)
         {
             if (EditStoreModel.USER_TUIDS != null && EditStoreModel.USER_TUIDS != string.Empty)
@@ -207,8 +221,7 @@
                     foreach (var addedUser in addedUsers)
                     {
                         var success = Users.TryAdd(addedUser.TUID, addedUser);
-                        Console.WriteLine(addedUser.TUID);
-                        await InvokeAsync(StateHasChanged);
+                        await InvokeAsync(StateHasChanged); // Needed to add employees
                     }
                 }
             }
@@ -239,6 +252,7 @@
         {
 
             ToastService.ShowError("There was an error editing the store!");
+            await InvokeAsync(ResetEditStoreModel);
         }
         else
         {
@@ -246,6 +260,8 @@
             await UpdateStores.InvokeAsync();
             StateHasChanged();
         }
+        await ClearEditStoreModel();
+
     }
 
     /// <summary>
@@ -259,13 +275,16 @@
     }
 
     /// <summary>
-    /// removes all of the values from the Model
+    /// removes all of the values from the Users, resets EditStoreModel,
+    /// resets background image, resets employees, and calls to UpdateUsers
     /// </summary>
     /// <param name=""> no parameters taken </param>
     /// <returns> void </returns>
     private async Task ClearEditStoreModel()
     {
         Users.Clear();
+        await InvokeAsync(ResetEditStoreModel);
+        await JS.InvokeVoidAsync("setBackgroundImage", StoreId, ImageSrc);
         EditStoreModel!.USER_TUIDS = EmployeesAtStart;
         await UpdateUsers();
 

--- a/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
+++ b/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
@@ -70,6 +70,7 @@
 
     /// <summary>
     /// Holds comma-delimited string of ids for users that are part of the store at initialization
+    /// or when restarting the modal
     /// Used to revert changes when clicking cancel
     /// </summary>
     private string? EmployeesAtStart;
@@ -241,8 +242,9 @@
             return;
         }
 
-
         string joinedEmployees = string.Join(",", Users.Keys.ToList());
+
+        EmployeesAtStart = joinedEmployees;
 
         EditStoreModel!.USER_TUIDS = joinedEmployees;
 
@@ -250,15 +252,13 @@
 
         if (response != System.Net.HttpStatusCode.OK)
         {
-
             ToastService.ShowError("There was an error editing the store!");
-            await InvokeAsync(ResetEditStoreModel);
         }
         else
         {
             ToastService.ShowSuccess("Your edits have been saved!");
             await UpdateStores.InvokeAsync();
-            StateHasChanged();
+            await InvokeAsync(StateHasChanged);
         }
         await ClearEditStoreModel();
 

--- a/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
+++ b/Plot/Components/Pages/StoreDashboard/EditStoreModal.razor
@@ -11,7 +11,7 @@
         <AddUpdateStoreModalBody AddUpdateStoreModel="EditStoreModel" StoreId="StoreId"
             AddEmployeeTarget="@($"#add-employee-{StoreId}")" Users="Users.Values.ToList()" DeleteUser="DeleteUser" />
 
-        <ModalFooter>
+        <ModalFooter OnCancelClick="async () => await ClearEditStoreModel()">
             <Button TextAlignment="center" Variant="primary" type="submit" data-bs-dismiss="modal">
                 Update Store
             </Button>
@@ -20,7 +20,7 @@
 </Modal>
 
 <AddEmployeeToStoreModal id="@($"add-employee-{Store.TUID}")" AddEmployeeTarget="@($"#edit-store-{Store.TUID}")"
-    OnAddEmployeesSubmit="OnAddEmployeesSubmit" />
+    OnAddEmployeesSubmit="OnAddEmployeesSubmit" ImageSrc="ImageSrc"/>
 
 @code {
     /// <summary>
@@ -54,6 +54,14 @@
     private Dictionary<int, Data.Models.Users.UserDTO> Users = new Dictionary<int, Data.Models.Users.UserDTO>();
 
     /// <summary>
+    /// Holds comma-delimited string of ids for users that are part of the store at initialization
+    /// Used to revert changes when clicking cancel
+    /// </summary>
+    private string? EmployeesAtStart;
+
+    private string? ImageSrc;
+
+    /// <summary>
     /// Updates the Users Dictionary to include all of the employees that should 
     /// be associated with the store
     /// </summary>
@@ -82,10 +90,12 @@
 
                 if (addedUsers != null)
                 {
-                    addedUsers.ForEach((addedUser) =>
+                    foreach (var addedUser in addedUsers)
                     {
-                        Users.TryAdd(addedUser.TUID, addedUser);
-                    });
+                        var success = Users.TryAdd(addedUser.TUID, addedUser);
+                        Console.WriteLine(addedUser.TUID);
+                        await InvokeAsync(StateHasChanged);
+                    }
                 }
             }
         }
@@ -121,6 +131,12 @@
             BLUEPRINT_IMAGE = Store.BLUEPRINT_IMAGE,
             USER_TUIDS = string.Empty
         };
+
+        ImageSrc = EditStoreModel!.BLUEPRINT_IMAGE != null ?
+        $"data:image/jpeg;base64,{Convert.ToBase64String(EditStoreModel!.BLUEPRINT_IMAGE)}" : "";
+
+        Console.WriteLine(EditStoreModel.BLUEPRINT_IMAGE);
+
     }
 
     /// <summary>
@@ -132,6 +148,7 @@
     protected override async Task OnInitializedAsync()
     {
         await UpdateUsers();
+        EmployeesAtStart = EditStoreModel!.USER_TUIDS;
     }
 
     /// <summary>
@@ -148,7 +165,27 @@
 
         EditStoreModel!.USER_TUIDS = joinedEmployees;
 
-        await UpdateUsers();
+        //await UpdateUsers();
+        if (EditStoreModel != null)
+        {
+            if (EditStoreModel.USER_TUIDS != null && EditStoreModel.USER_TUIDS != string.Empty)
+            {
+                var addedUsers = await UsersHttpClient.GetUsersByString(new Data.Models.Users.UsersByStringRequest()
+                {
+                    TUIDS = EditStoreModel.USER_TUIDS
+                });
+
+                if (addedUsers != null)
+                {
+                    foreach (var addedUser in addedUsers)
+                    {
+                        var success = Users.TryAdd(addedUser.TUID, addedUser);
+                        Console.WriteLine(addedUser.TUID);
+                        await InvokeAsync(StateHasChanged);
+                    }
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -199,8 +236,12 @@
     /// </summary>
     /// <param name=""> no parameters taken </param>
     /// <returns> void </returns>
-    private void ClearEditStoreModel()
+    private async Task ClearEditStoreModel()
     {
-        EditStoreModel = new();
+        Users.Clear();
+        EditStoreModel!.USER_TUIDS = EmployeesAtStart;
+        await UpdateUsers();
+
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/Plot/Components/Pages/StoreDashboard/StoreDashboard.razor
+++ b/Plot/Components/Pages/StoreDashboard/StoreDashboard.razor
@@ -39,12 +39,11 @@ Author: Andrew Fulton (3/12/2025)
     @foreach (var Store in Stores)
     {
         var ImageSrc = Store.BLUEPRINT_IMAGE != null ?
-        $"data:image/jpeg;base64,{Convert.ToBase64String(Store.BLUEPRINT_IMAGE)}" :
-        "https://placecats.com/300/200";
+        $"data:image/jpeg;base64,{Convert.ToBase64String(Store.BLUEPRINT_IMAGE)}" : "";
 
         <Card>
             <a href="@($"/floorsets/{Store.TUID}")" class="w-100 ratio ratio-4x3">
-                <CardImage Image="@ImageSrc" />
+                <CardImage Image="@ImageSrc" AltText="@Store.NAME" />
             </a>
             <CardBody>
                 <CardTitle class="flex-grow-1">

--- a/Plot/Components/PartialComponents/Card/CardImage.razor
+++ b/Plot/Components/PartialComponents/Card/CardImage.razor
@@ -1,7 +1,9 @@
-<img class="card-img-top object-fit-cover" src="@Image" alt="Card image cap" @attributes="Attributes" />
+<img class="card-img-top object-fit-cover" src="@Image" alt="@AltText" @attributes="Attributes" />
 
 @code {
     [Parameter] public required string Image { get; set; }
+
+    [Parameter] public string AltText {get; set; } = "Card image cap";
 
     [Parameter(CaptureUnmatchedValues = true)] public required Dictionary<string, object> Attributes { get; set; }
 }


### PR DESCRIPTION
Turned out to be a rendering issue. From the beginning the correct employees would show but only once I refreshed the page. After this fix all information including employee information should update on the user interface (without needing to refresh) when hitting "Save" in the Add Store and Edit Store modals and only when hitting save.

As it should, adding employees displays the employees selected in the Add Employee modal in the Add Store or Edit Store modal but also does not persist unless you hit save.

Bug caused first employee selected in Add Store modal not to appear due to using .skip(1) to handle the Root user. I changed it to check if the USER.TUID is 0 to exclude Root User that way. With this fix, all employees that are added by the user display in both modals.

Images when uploaded and saved persist. Images when uploaded and you hit cancel do not.

Additionally I have created an AltText property in the CardImage component. I set it to the hard-coded default for when it is not set, and have set it to be the Store Name within the Store Dashboard.

