### PR TITLE
Fixed Bug - Owners can now edit owners

### DIFF
--- a/Plot/Components/Pages/UserDashboard/AddUpdateUserModalBody.razor
+++ b/Plot/Components/Pages/UserDashboard/AddUpdateUserModalBody.razor
@@ -1,23 +1,21 @@
+@*
+File Purpose:
+Add Update User Modal Body
+
+Program Purpose:
+The purpose of PLOT is to allow users to easily create, manage, 
+and allocate floorsets for Platos Closet. 
+
+*@
+
 @inject UsersHttpClient UsersHttpClient
 @inject StoresHttpClient StoresHttpClient
 @inject IJSRuntime JS
 @using Data.Models.Users
 @using Microsoft.AspNetCore.Components.Authorization;
 
-@*
-Select-first-after-moving-task (commented out code used towards this)
-
-This code is meant to select the first item in the select boxes, to avoid having it gray-highlight
-a store in the select boxes and then not move it when the user clicks the button
-But as is right now it doens't work.
-Current solution is the paragraph says to use Ctrl-Click before pressing buttons.
-And this will need to be included in training
-
-Referenced in other comments in this file as: Select-first-after-moving-task
-
-*@
-
 <ModalBody>
+    @* First Name field *@
     <label class="w-100 d-flex mt-2">
         <span class="mt-2 fw-bold">First Name</span>
         <InputText class="w-85 form-control ms-auto" type="Text" @bind-value="AddUpdateUserModel!.FIRST_NAME" />
@@ -25,6 +23,7 @@ Referenced in other comments in this file as: Select-first-after-moving-task
             <ValidationMessage For=@(() => AddUpdateUserModel.FIRST_NAME) />
         </div>
     </label>
+    @* Last Name field *@
     <label class="w-100 d-flex my-2">
         <span class="mt-2 fw-bold">Last Name</span>
         <InputText class="w-85 form-control ms-auto" type="Text" @bind-value="AddUpdateUserModel!.LAST_NAME" />
@@ -33,6 +32,7 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         </div>
     </label>
 
+    @* Email field *@
     <label class="w-100 d-flex my-2">
         <span class="mt-2 fw-bold">Email</span>
         <InputText class="w-85 form-control ms-auto" type="Text" @bind-value="AddUpdateUserModel!.EMAIL" />
@@ -41,6 +41,7 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         </div>
     </label>
 
+    @* Role select box *@
     <label class="w-100 d-flex my-2">
         <span class="mt-2 fw-bold">Role</span>
         <InputSelect class="w-85 form-select ms-auto" @bind-value="AddUpdateUserModel!.ROLE_NAME">
@@ -55,11 +56,14 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         </div>
     </label>
 
+    @* Store Access *@
     <p id="StoreSelectHeader" class="fw-bold">Store Selection</p>
 
     <p>To select stores and move them use Ctrl-click to highlight stores before pressing the buttons</p>
 
     <div class="w-100 d-flex justify-content-around">
+
+        @* Stores the user does not have access to *@
         <label class="w-25">
             Available Stores
             <select class="form-select mb-4 h-50 w-100" id="unassigned-stores" size="3" multiple
@@ -78,6 +82,7 @@ Referenced in other comments in this file as: Select-first-after-moving-task
 
         </label>
 
+        @* Stores the user has access to *@
         <label class="w-25">
             Selected Stores
             <select class="form-select mb-4 h-50 w-100" id="assigned-stores" size="3" multiple
@@ -97,86 +102,118 @@ Referenced in other comments in this file as: Select-first-after-moving-task
 
 </ModalBody>
 
-@* Select-first-after-moving-task *@
-@*
-<script>
-    function selectFirstItem(selectElementId) {
-        // Select the first item
-        var selectElement = document.getElementById(selectElementId);
-        for (var i = 0; i < selectElement.options.length; i++) {
-            selectElement.options[i].selected = false;
-        }
-        if (selectElement && selectElement.options.length > 0) {
-            selectElement.options[0].selected = true;
-        }
-
-        // Trigger the onchange event
-        var event = new Event('change', { bubbles: true });
-        selectElement.dispatchEvent(event);
-    }
-</script>
-*@
-
 @code {
 
-    // Parameters
+    /// <summary>
+    /// Event callback for use when this component initializes to signal parent components
+    /// that it is initialized. Needed to consistently render stores
+    /// </summary>
     [Parameter] public EventCallback OnInit { get; set; }
 
+    /// <summary>
+    /// Model used for updating information on user first name, last name, email, and role in the database
+    /// Parameter supplied from parent component
+    /// </summary>
     [Parameter] public Data.Models.Users.UpdatePublicInfoUser? AddUpdateUserModel { get; set; }
 
+    /// <summary>
+    /// Model used for adding and updating store access
+    /// </summary>
     [Parameter] public List<Data.Models.Users.AddUserToStoreRequest>? AddUpdateUserStoreRequestModels { get; set; }
 
-    // Stores Assigned or unassigned - Used for tracking assignment/unassignment in the modal before submit
-    // and for submitting the data when submit is clicked
+    /// <summary>
+    /// List of stores the user has access to
+    /// </summary>
     [Parameter] public List<Data.Models.Stores.Store>? AssignedStores { get; set; }
 
+    /// <summary>
+    /// List of stores the user does not have access to
+    /// </summary>
     [Parameter] public List<Data.Models.Stores.Store>? UnassignedStores { get; set; }
 
+    /// <summary>
+    /// Update Users callback for rerendering UserDashboard
+    /// </summary>
     [Parameter] public required EventCallback UpdateUsers { get; set; }
 
+    /// <summary>
+    /// Event callback to signal parent component that assigned stores have changed within modal
+    /// </summary>
     [Parameter] public EventCallback<List<Data.Models.Stores.Store>?> SignalParentAssignedStoresChanged { get; set; }
 
+    /// <summary>
+    /// Event callback to signal parent component that unassigned stores have changed within modal
+    /// </summary>
     [Parameter] public EventCallback<List<Data.Models.Stores.Store>?> SignalParentUnassignedStoresChanged { get; set; }
 
-    // Parameter to disable submit button in parent modal
-    // Needed briefly in case of moving stores between select boxes,
-    // pressing submit too quickly after selecting stores can cause stores not to update
+    /// <summary>
+    /// Parameter to disable submit button in parent modal
+    /// Needed briefly in case of moving stores between select boxes,
+    /// pressing submit too quickly after selecting stores can cause stores not to update
+    /// </summary>
     [Parameter] public EventCallback<bool> DisableSubmitInParent { get; set; }
 
-    private const int NEW_USER = 0; // Indicates new user when initializing stores
+    /// <summary>
+    /// New User flag, used when initializing stores. 0 is chosen since no user to be displayed in the User Dashboard
+    /// has a TUID of 0. It is specifically excluded due to being Root's TUID, and we never update Root, so it's
+    /// safe to use as a flag for when a new user is being added
+    /// </summary>
+    private const int NEW_USER = 0;
 
-    private bool IsSelectButtonsDisabled = false; // For disabling select buttons --- Needed to ensure related
-                                                  //data is updated
+    /// <summary>
+    /// Flag for disabling select buttons. This is needed briefly (imperceptibly in tests) to prevent submit from
+    /// being pressed before the models to update access have updated.
+    /// </summary>
+    private bool IsSelectButtonsDisabled = false;
 
-    // Prevents error where clicking the button does nothing due to it not having updated
-
-    // Lists of store tuids representing stores currently selected in either "Available Stores"
-    // or in "Selected Stores"
+    /// <summary>
+    /// List of TUIDs the user selected in the select box for stores
+    /// the user does not have
+    /// </summary>
     public List<int> selectedUnassignedTUIDs { get; set; } = new();
 
+    /// <summary>
+    /// List of TUIDs the user selected in the select box for stores
+    /// the user has
+    /// </summary>
     public List<int> selectedAssignedTUIDs { get; set; } = new();
 
+    /// <summary>
+    /// Calls state has changed from parent to tell child component
+    /// to change state. Added while resolving 
+    /// inconsistent data display issues related to Blazor's
+    /// rendering cycles
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public void StateHasChangedFromParent()
     {
         // Signal StateHasChanged from parent
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Stores selected in select box from "Available Stores" moved to "Selected Stores"
+    /// Stores selected from UnassignedStores are moved to AssignedStores
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public async Task SelectStoresForUser()
     {
-        // Stores selected in select box from "Available Stores" moved to "Selected Stores"
-        // Stores selected from UnassignedStores are moved to AssignedStores
-
         // Disable submit button in parent component while stores are
         // moved between select boxes
-
         await DisableSubmitInParent.InvokeAsync(true);
 
-        await Task.Delay(10); // Give onchange event for selection time to work
+        // Give the onchange event time to work when selecting users
+        await Task.Delay(10);
 
+        // Stores being moved (assigned)
         var storesToMove = UnassignedStores?.Where(store => selectedUnassignedTUIDs.Contains(store.TUID)).ToList();
         if (storesToMove == null) { return; }
 
+        // Add stores to assgined stores
+        // Remove stores from unassigned stores
+        // Clear selected Unassigned TUIDs
         foreach (var store in storesToMove)
         {
             AssignedStores?.Add(store);
@@ -184,8 +221,6 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         }
         selectedUnassignedTUIDs.Clear();
 
-        // TODO: See: Select-first-after-moving-task
-        //await JS.InvokeVoidAsync("selectFirstItem", "unassigned-stores");
         StateHasChanged();
 
         // Signal parent component to update stores lists
@@ -198,26 +233,32 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Stores selected in select box from "Selected Stores" moved to "Available Stores"
+    /// Stores selected from AssignedStores are moved to UnassignedStores
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public async Task RemoveStoresFromUser()
     {
-        Console.WriteLine("Remove store from user");
         // Disable submit button while stores are
         // moved between select boxes
         await DisableSubmitInParent.InvokeAsync(true);
 
+        // Stores being moved (assigned)
         var storesToMove = AssignedStores?.Where(store => selectedAssignedTUIDs.Contains(store.TUID)).ToList();
         if (storesToMove == null) return;
 
+        // Add stores to assgined stores
+        // Remove stores from unassigned stores
+        // Clear selected Unassigned TUIDs
         foreach (var store in storesToMove)
         {
             UnassignedStores?.Add(store);
             AssignedStores?.Remove(store);
         }
-
         selectedAssignedTUIDs.Clear();
 
-        //TODO: See: Select-first-after-moving-task
-        //await JS.InvokeVoidAsync("selectFirstItem", "assigned-stores");
         StateHasChanged();
 
         // Signal parent component to update stores lists
@@ -230,7 +271,11 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         StateHasChanged();
     }
 
-    // Methods handle selection of store TUIDs in select boxes
+    /// <summary>
+    /// Handle selection of assigned stores (stores in "Selected Stores select box")
+    /// </summary>
+    /// <param name="e"> Change Event Argument passed when new stores are selected </param>
+    /// <returns> void </returns>
     public void AssignedStoresSelection(ChangeEventArgs e)
     { // Selected from list of assigned stores for potential removal
       // and placement in list of unassigned stores
@@ -240,6 +285,11 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Handle selection of unassgined stores (stores in "Available Stores select box")
+    /// </summary>
+    /// <param name="e"> Change Event Argument passed when new stores are selected </param>
+    /// <returns> void </returns>
     public void UnassignedStoresSelection(ChangeEventArgs e)
     {
         // Selected from list of unassigned stores for potential
@@ -250,6 +300,11 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Handle selection of unassgined stores (stores in "Available Stores select box")
+    /// </summary>
+    /// <param name="e"> Change Event Argument passed when new stores are selected </param>
+    /// <returns> List<int> </returns>
     private List<int> ExtractSelectedIds(ChangeEventArgs e)
     {
         // Put selected options into list of store ids
@@ -265,10 +320,14 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         return selected;
     }
 
+    /// <summary>
+    /// Updates User of given userTUID for information including first name,
+    /// last name, email, and role via call through backend to database
+    /// </summary>
+    /// <param name="userTUID"> TUID of user being updated </param>
+    /// <returns> void </returns>
     public async Task UpdateUser(int userTUID)
     {
-        // Updates information for user including first name, last name, email, and role
-
         if (AddUpdateUserModel != null)
         {
             var response = await UsersHttpClient.UpdateUserPublicInfo(userTUID, AddUpdateUserModel!);
@@ -277,9 +336,15 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Initializes assigned stores and unassigned for user of given userTUID
+    /// </summary>
+    /// <param name="userTUID"> TUID of user being updated.
+    /// NEW_USER=0 is used as a flag in case it is a new user </param>
+    /// <returns> void </returns>
     public async Task InitUserStores(int userTUID)
     {
-        // Initializes stores for user of TUID, userTUID
+        // Initializes assigned and unassigned stores for user of TUID, userTUID
 
         await InitAssignedStores(userTUID);
         await InitUnassignedStores(userTUID);
@@ -291,6 +356,12 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         await OnInit.InvokeAsync();
     }
 
+    /// <summary>
+    /// Initializes assigned stores for user of given userTUID
+    /// </summary>
+    /// <param name="userTUID"> TUID of user being updated.
+    /// NEW_USER=0 is used as a flag in case it is a new user </param>
+    /// <returns> void </returns>
     private async Task InitAssignedStores(int userTUID)
     {
         // Initialize assigned stores for select box in add user or update user modal
@@ -310,15 +381,21 @@ Referenced in other comments in this file as: Select-first-after-moving-task
         }
     }
 
+    /// <summary>
+    /// Initializes unassigned stores for user of given userTUID
+    /// </summary>
+    /// <param name="userTUID"> TUID of user being updated.
+    /// NEW_USER=0 is used as a flag in case it is a new user </param>
+    /// <returns> void </returns>
     private async Task InitUnassignedStores(int userId)
     {
         // Initialize unassigned stores for select box in add user or update user modal
 
-        UnassignedStores!.Clear(); // Clear unassigned stores list
+        // Clear unassigned stores list
+        UnassignedStores!.Clear();
         if (userId == NEW_USER)
         {
-            // New user - Fill available stores list
-
+            // New user - all stores are unassigned - get full list of stores
             var response = await StoresHttpClient.GetListOfStores();
             if (response != null)
             {
@@ -334,7 +411,8 @@ Referenced in other comments in this file as: Select-first-after-moving-task
 
             if (response != null)
             {
-                UnassignedStores.AddRange(response); // Add stores to unassigned stores
+                // Add stores to unassigned stores
+                UnassignedStores.AddRange(response);
             }
         }
     }

--- a/Plot/Components/Pages/UserDashboard/AddUserModal.razor
+++ b/Plot/Components/Pages/UserDashboard/AddUserModal.razor
@@ -1,3 +1,13 @@
+@*
+File Purpose:
+Add User Modal for adding users.
+
+Program Purpose:
+The purpose of PLOT is to allow users to easily create, manage, 
+and allocate floorsets for Platos Closet. 
+
+*@
+
 @inject AuthHttpClient AuthHttpClient
 @inject StoresHttpClient StoresHttpClient
 @inject UsersHttpClient UsersHttpClient
@@ -29,7 +39,9 @@
 </Modal>
 
 <script>
-
+// Gets instance of modal. This was put here as part of enabling the functionality of the Load Message modal.
+// This does not appear to be in use in the current implementation but as of (4/28/2025) deadline is
+// tomorrow (4/29/2025) so I'm leaving this in just in case. - Andrew Miller
     window.getModalInstance = function (selector) {
         return window.bootstrap.Modal.getOrCreateInstance(document.querySelector(selector));
     };
@@ -37,35 +49,76 @@
 
 @code {
 
+    /// <summary>
+    /// Attributes dictionary parameter
+    /// </summary>
     [Parameter(CaptureUnmatchedValues = true)] public required Dictionary<string, object> Attributes { get; set; }
 
+    /// <summary>
+    /// Model used for updating information on user first name, last name, email, and role in the database
+    /// </summary>
     [SupplyParameterFromForm] private Data.Models.Users.UpdatePublicInfoUser? AddUserModel { get; set; }
 
+    /// <summary>
+    /// Model representing the user and data associated with the user
+    /// </summary>
     [Parameter] public required Data.Models.Users.UserDTO? User { get; set; }
 
+    /// <summary>
+    /// Update Users callback for rerendering UserDashboard
+    /// </summary>
     [Parameter] public required EventCallback UpdateUsers { get; set; }
 
-    // Show or hide Loading Message Modal
+    /// <summary>
+    /// Callback to show loading modal
+    /// </summary>
     [Parameter] public EventCallback<string> ShowLoadingModal { get; set; }
 
+    /// <summary>
+    /// Callback to hide loading modal
+    /// </summary>
     [Parameter] public EventCallback<string> HideLoadingModal { get; set; }
 
-    private const int NEW_USER = 0; // Indicates new user when initializing stores
+    /// <summary>
+    /// Constant for New user - Indicates new user when initializing stores
+    /// </summary>
+    private const int NEW_USER = 0;
 
-    private bool modalBodyInit = false; // AddUpateUserModalBody initialized flag
+    /// <summary>
+    /// Flags that the AddUpdateUserModalBody has been initialized
+    /// </summary>
+    private bool modalBodyInit = false;
 
-    private bool IsSubmitDisabled = false; // Disable submit button
+    /// <summary>
+    /// Determines if submit button is disabled
+    /// </summary>
+    private bool IsSubmitDisabled = false;
 
-    public AddUpdateUserModalBody? modalBodyRef; // Ref for AddUpdateUserModalBody
+    /// <summary>
+    /// Reference for AddUpdateUserModalBody component
+    /// </summary>
+    public AddUpdateUserModalBody? modalBodyRef;
 
-    // AddUserStores and NotAddUserStores
+    /// <summary>
+    /// List of stores the user has access to
+    /// </summary>
     public List<Data.Models.Stores.Store> AddUserStores = new();
 
+    /// <summary>
+    /// List of stores the user does not have access to
+    /// </summary>
     public List<Data.Models.Stores.Store> NotAddUserStores = new List<Data.Models.Stores.Store>();
 
-    // Model for getting user from email
+    /// <summary>
+    /// Data Model for getting user from email
+    /// </summary>
     public Data.Models.Users.UserDTO? UserFromEmail { get; set; }
 
+    /// <summary>
+    /// Updates UpdateUserModel on initialization from User's data
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     protected override async Task OnInitializedAsync()
     {
         AddUserModel ??= new() // Iniitalize AddUserModel with Role of "Employee"
@@ -87,6 +140,12 @@
         }
     }
 
+    /// <summary>
+    /// Initializes stores after render if the AddUpdateUserModalBody
+    /// has been initialized and it hasn't already initialized stores
+    /// </summary>
+    /// <param name="firstRender"> Built-in parameter refers to whether render is the first render </param>
+    /// <returns> void </returns>
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!modalBodyInit)
@@ -99,6 +158,12 @@
         }
     }
 
+    /// <summary>
+    /// For being called by the child component to signal
+    /// that it has been initialized
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public void HandleBodyInit()
     {
         // When modal body is initiated, the AddUpdateUserModalBody.razor
@@ -111,6 +176,11 @@
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Runs when new user is submitted via submit button for form in this modal
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     private async Task OnAddUserSubmit()
     {
         // When Submit is clicked in this modal:
@@ -168,6 +238,11 @@
         ToastService.ShowSuccess("The user was created.");
     }
 
+    /// <summary>
+    /// Clears the Add User Modal
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public async Task ClearAddUserModal()
     {
         // Clear add user modal
@@ -182,21 +257,34 @@
         await modalBodyRef!.InitUserStores(NEW_USER);
     }
 
+    /// <summary>
+    /// Handles change in user stores within modal
+    /// </summary>
+    /// <param name="NewUpdateUserStores"> List<Data.Models.Stores.Store> New list of models reflecting stores user has </param>
+    /// <returns> void </returns>
     public void HandleUserStoresChange(List<Data.Models.Stores.Store> NewAddUserStores)
     {
         AddUserStores = NewAddUserStores;
     }
 
+    /// <summary>
+    /// Handles change in not user stores within modal
+    /// </summary>
+    /// <param name="NewNotAddUserStores"> List<Data.Models.Stores.Store> New list of models reflecting stores use does not have </param>
+    /// <returns> void </returns>
     public void HandleNotUserStoresChange(List<Data.Models.Stores.Store> NewNotAddUserStores)
     {
         NotAddUserStores = NewNotAddUserStores;
     }
 
+    /// <summary>
+    /// Disables submit from child component - from AddUpdateUserModalBody.razor.
+    /// Needed for when stores are moved between select boxes
+    /// </summary>
+    /// <param name=isDisabled""> Determines if is submit is disabled.</param>
+    /// <returns> void </returns>
     public void DisableSubmitFromChild(bool isDisabled)
     {
-        // Disable submit button from child
-        // This disables the submit button temporarily
-        // while stores are moved between select boxes
         IsSubmitDisabled = isDisabled;
     }
 }

--- a/Plot/Components/Pages/UserDashboard/DeleteUserModal.razor
+++ b/Plot/Components/Pages/UserDashboard/DeleteUserModal.razor
@@ -1,3 +1,13 @@
+@*
+File Purpose:
+Delete User Modal for deleting users.
+
+Program Purpose:
+The purpose of PLOT is to allow users to easily create, manage, 
+and allocate floorsets for Platos Closet. 
+
+*@
+
 @inject UsersHttpClient UsersHttpClient
 @inject ToastService ToastService
 
@@ -15,6 +25,8 @@ Backdrop="static" Keyboard="false"
             private string? deleteTextInput;
             private bool isDisabled => deleteTextInput != "DELETE";
         }
+
+        @* Ask if user (using dashboard) wants to delete employee*@
         <ModalBody>
             <h2>Are you SURE you want to delete this user?</h2>
             <input class="form-control w-100" type="text" placeholder="If so, type DELETE below" required
@@ -31,14 +43,29 @@ Backdrop="static" Keyboard="false"
 </Modal>
 
 @code {
+    /// <summary>
+    /// TUID of user this delete user modal pertains to
+    /// </summary>
     [Parameter] public required int userTuid { get; set; }
 
+    /// <summary>
+    /// Update Users callback for rerendering UserDashboard
+    /// </summary>
     [Parameter] public required EventCallback UpdateUsers { get; set; }
 
+    /// <summary>
+    /// Attributes dictionary parameter
+    /// </summary>
     [Parameter(CaptureUnmatchedValues = true)] public required Dictionary<string, object> Attributes { get; set; }
 
+    /// <summary>
+    /// When submit button is pressed - Delete the user
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     private async Task OnDeleteUserSubmit(int userId)
     {
+        // Call backend to signal database to delete user
         var response = await UsersHttpClient.DeleteUserById(userId);
 
         if(response != System.Net.HttpStatusCode.OK) {
@@ -47,6 +74,7 @@ Backdrop="static" Keyboard="false"
             ToastService.ShowSuccess("The user was deleted.");
         }
 
+        // Update User Dashboard
         await UpdateUsers.InvokeAsync();
     }
 }

--- a/Plot/Components/Pages/UserDashboard/LoadMessageModal.razor
+++ b/Plot/Components/Pages/UserDashboard/LoadMessageModal.razor
@@ -1,7 +1,11 @@
 @inject IJSRuntime JS
 @using Microsoft.JSInterop
 
-@* data-bs-backdrop="static" prevents closing when the user clicks outside of it
+@* 
+Load Message Modal - Presents a message indicating data is being updated
+when a new user is added. Needed to warn user from navigating away from page
+
+data-bs-backdrop="static" prevents closing when the user clicks outside of it
 data-bs-keyboard="false" prevents closing when the user clicks the escape key
 
 data-bs-backdrop="static" does not work on Firefox.
@@ -15,7 +19,9 @@ data-bs-backdrop="static" does not work on Firefox.
 </Modal>
 
 <script>
-
+// Gets instance of modal. This was put here as part of enabling the functionality of this modal.
+// This does not appear to be in use in the current implementation but as of (4/28/2025) deadline is
+// tomorrow (4/29/2025) so I'm leaving this in just in case. - Andrew Miller
     window.getModalInstance = function (selector) {
         return window.bootstrap.Modal.getOrCreateInstance(document.querySelector(selector));
     };

--- a/Plot/Components/Pages/UserDashboard/UpdateUserModal.razor
+++ b/Plot/Components/Pages/UserDashboard/UpdateUserModal.razor
@@ -1,3 +1,14 @@
+@*
+File Purpose:
+Update User Modal for editing users. May edit first name,
+last name, email, role, and store access.
+
+Program Purpose:
+The purpose of PLOT is to allow users to easily create, manage, 
+and allocate floorsets for Platos Closet. 
+
+*@
+
 @inject StoresHttpClient StoresHttpClient
 @inject UsersHttpClient UsersHttpClient
 @inject IJSRuntime JS
@@ -30,37 +41,74 @@
 
 @code {
 
-    // Parameters
+    /// <summary>
+    /// Attributes dictionary parameter
+    /// </summary>
     [Parameter(CaptureUnmatchedValues = true)] public required Dictionary<string, object> Attributes { get; set; }
 
-    // Model used for updating information on user first name, last name, email, and role in the database
+    /// <summary>
+    /// Model used for updating information on user first name, last name, email, and role in the database
+    /// </summary>
     [SupplyParameterFromForm] private Data.Models.Users.UpdatePublicInfoUser? UpdateUserModel { get; set; }
 
-    // Model representing the user
+    /// <summary>
+    /// Model representing the user and data associated with the user
+    /// </summary>
     [Parameter] public required Data.Models.Users.UserDTO? User { get; set; }
 
-    // Update Users callback for rerendering UserDashboard in UserDashboard.razor file
+    /// <summary>
+    /// Update Users callback for rerendering UserDashboard
+    /// </summary>
     [Parameter] public required EventCallback UpdateUsers { get; set; }
 
-    public AddUpdateUserModalBody? modalBodyRef; // Ref for AddUpdateUserModalBody
+    /// <summary>
+    /// Reference for AddUpdateUserModalBody component
+    /// </summary>
+    public AddUpdateUserModalBody? modalBodyRef;
 
-    private bool modalBodyInit = false; // AddUpateUserModalBody initialized flag
+    /// <summary>
+    /// Flags that the AddUpdateUserModalBody has been initialized
+    /// </summary>
+    private bool modalBodyInit = false;
 
-    private bool IsSubmitDisabled = false; // Disable submit button
+    /// <summary>
+    /// Determines if submit button is disabled
+    /// </summary>
+    private bool IsSubmitDisabled = false;
 
-    // Modal for updating First Name, Last Name, Email, Role of User
+    /// <summary>
+    /// Model for updating First Name, Last Name, Email, Role of User
+    /// Used for sending data to database
+    /// </summary>
     public Data.Models.Users.UpdatePublicInfoUser? AddUpdateUserModel = new();
 
-    // Stores lists for updating access
-
+    /// <summary>
+    /// List of stores the user has access to
+    /// </summary>
     public List<Data.Models.Stores.Store> UpdateUserStores = new();
 
+    /// <summary>
+    /// List of stores the user does not have access to
+    /// </summary>
     public List<Data.Models.Stores.Store> NotUpdateUserStores = new();
 
+    /// <summary>
+    /// List of TUIDs the user selected in the select box for stores
+    /// the user does not have
+    /// </summary>
     public List<int> selectedNotUserStoreTUIDs = new();
 
+    /// <summary>
+    /// List of TUIDs the user selected in the select box for stores
+    /// the user does have
+    /// </summary>
     public List<int> selectedUserStoreTUIDs = new();
 
+    /// <summary>
+    /// Updates UpdateUserModel on initialization from User's data
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     protected override void OnInitialized()
     {
 
@@ -74,6 +122,12 @@
 
     }
 
+    /// <summary>
+    /// Initializes stores after render if the AddUpdateUserModalBody
+    /// has been initialized and it hasn't already initialized stores
+    /// </summary>
+    /// <param name="firstRender"> Built-in parameter refers to whether render is the first render </param>
+    /// <returns> void </returns>
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!modalBodyInit)
@@ -86,6 +140,12 @@
         }
     }
 
+    /// <summary>
+    /// For being called by the child component to signal
+    /// that it has been initialized
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public void HandleBodyInit()
     {
 
@@ -97,6 +157,11 @@
         StateHasChanged();
     }
 
+    /// <summary>
+    /// Runs when submitting form in modal
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public async Task OnUpdateUserSubmit()
     {
         if (UpdateUserModel == null)
@@ -105,6 +170,7 @@
             return;
         }
 
+        // Update the user's info: first name, last name, email, role
         var response = await UsersHttpClient.UpdateUserPublicInfo(User!.TUID, UpdateUserModel);
 
         if (response != System.Net.HttpStatusCode.OK)
@@ -115,6 +181,7 @@
         {
             ToastService.ShowSuccess("The user was edited.");
 
+            // Update store access for user
             await UsersHttpClient.UpdateAccessList(new Data.Models.Users.UpdateAccessListRequest
             {
                 USER_TUID = User!.TUID,
@@ -122,11 +189,18 @@
             });
         }
 
+        // Update User Dashboard
         await UpdateUsers.InvokeAsync();
 
+        // Clear Update User Model and Modal
         ClearUpdateUserModel();
     }
 
+    /// <summary>
+    /// Gives state change in the Update User Modal and the modal body
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public void ClearUpdateUserModel()
     {
         if (modalBodyRef != null)
@@ -135,19 +209,34 @@
         }
 
         StateHasChanged();
-
     }
 
+    /// <summary>
+    /// Handles change in user stores within modal
+    /// </summary>
+    /// <param name="NewUpdateUserStores"> List<Data.Models.Stores.Store> New list of models reflecting stores user has </param>
+    /// <returns> void </returns>
     public void HandleUserStoresChange(List<Data.Models.Stores.Store> NewUpdateUserStores)
     {
         UpdateUserStores = NewUpdateUserStores;
     }
 
+    /// <summary>
+    /// Handles change in not user stores within modal
+    /// </summary>
+    /// <param name="NewNotUpdateUserStores"> List<Data.Models.Stores.Store> New list of models reflecting stores use does not have </param>
+    /// <returns> void </returns>
     public void HandleNotUserStoresChange(List<Data.Models.Stores.Store> NewNotUpdateUserStores)
     {
         NotUpdateUserStores = NewNotUpdateUserStores;
     }
 
+    /// <summary>
+    /// Disables submit from child component - from AddUpdateUserModalBody.razor.
+    /// Needed for when stores are moved between select boxes
+    /// </summary>
+    /// <param name=isDisabled""> Determines if is submit is disabled.</param>
+    /// <returns> void </returns>
     public void DisableSubmitFromChild(bool isDisabled)
     {
         IsSubmitDisabled = isDisabled;

--- a/Plot/Components/Pages/UserDashboard/UserDashboard.razor
+++ b/Plot/Components/Pages/UserDashboard/UserDashboard.razor
@@ -114,22 +114,6 @@ boxes for adding/updating names, email, role, and store access.
                                     
                                 </AuthorizeView>
 
-                                <AuthorizeView Policy="Owner">
-                                @* For Role Options Dropdown menu: Included to allow users of role owner to edit owner *@
-
-                                @if (user.ROLE == "Owner")
-                                {
-                                    <Dropdown id="@($"Dropdown-{user.TUID}")" LabelText="Role">
-                                        <DropdownLink Icon="fa-solid fa-pen-to-square" data-bs-toggle="modal"
-                                            data-bs-target="@($"#update-user-modal-{user.TUID}")">Edit</DropdownLink>
-                                        <DropdownLink Icon="fa-regular fa-trash-can" data-bs-toggle="modal"
-                                            data-bs-target="@($"#delete-user-modal-{user.TUID}")">
-                                            Delete
-                                        </DropdownLink>
-                                    </Dropdown>
-                                }
-                                    
-                                </AuthorizeView>
                             </div>
                         </td>
                     </tr>

--- a/Plot/Components/Pages/UserDashboard/UserDashboard.razor
+++ b/Plot/Components/Pages/UserDashboard/UserDashboard.razor
@@ -5,25 +5,41 @@ Employee Name, Employee ID, And Role visible on dashboard.
 Editing allows changes to name, role, and stores the user
 can access.
 
-Note:
-Database is not hooked up yet, so a lot of functionality here
-will be replaced with functionality that gets information from
-the database.
-
 Program Purpose:
 The purpose of PLOT is to allow users to easily create, manage, 
 and allocate floorsets for Platos Closet. 
 
-Author (Developed from skeleton): Andrew Miller (3/14/2025)
-Note: A small amount of skeleton code was present before. 
-No author was given.
+Author: Andrew Miller (3/14/2025): Set up the User Dashboard user interface functionality
+Note: A small amount of code was present before but no User Dashboard. No author was given.
 
 Andrew Kenendy (4/17/2025)
 Added a loader popup when a user is added.
 
-Andrew Miller (4/22/2025) - Store access - Loader placed into modal
+Andrew Miller (4/22/2025) - User Dashboard can be used to assign and reassign store access.
+Loader modal replaces loader popup when a user is added since interruption can cause a
+partial update (user information being recorded but without store access).
 
-*/
+Further Note (Andrew Miller 4/28/2025):
+The User Dashboard has this file (UserDashboard.razor) as the parent component, with
+the following child components:
+
+The Add User Modal (AddUserModal.razor) for adding a new user to the database.
+This is launched when clicking "Add User" on the dashboard.
+
+The Update User Modal (UpdateUserModal.razor) for updating a user in the database.
+This is launched when clicking "Edit" in the dropdown in UpdateUserModal.razor.
+
+The Delete User Modal (DeleteUserModal.razor) for "deleting" a user. The user won't
+appear on the User Dashboard, but is actually marked to inactivate the user.
+
+The Load Message Modal (LoadMessageModal.razor) which displays a modal informing
+the user data is being loaded to the database in the case of adding a new user,
+warning the user against navigating away and potentially causing an incomplete update
+to the database.
+
+The AddUpdateUserModalBody.razor file is the shared body as well as shared logic between
+the Add User Modal and the Update User Modal. It contains all of the fields and select
+boxes for adding/updating names, email, role, and store access.
 
 *@
 
@@ -79,8 +95,9 @@ Andrew Miller (4/22/2025) - Store access - Loader placed into modal
                                 @* Role of User*@
                                 <span class="flex-grow-1 align-self-center">@user.ROLE</span>
 
+                                @* Role Options Dropdown menu with id dynamically reflecting the id of the user Provides Edit and Delete options which open Edit User and Delete User Modals *@
                                 <AuthorizeView Policy="Manager">
-                                    @* Role Options Dropdown menu with id dynamically reflecting the id of the user Provides Edit and Delete options which open Edit User and Delete User Modals *@
+                                    @* Managers not allowed to edit owners*@
 
                                     @* Danielle Smith - 4/23/25 DO NOT LET MANAGERS EDIT OWNERS *@
                                     @if (user.ROLE != "Owner")
@@ -94,6 +111,24 @@ Andrew Miller (4/22/2025) - Store access - Loader placed into modal
                                             </DropdownLink>
                                         </Dropdown>
                                     }
+                                    
+                                </AuthorizeView>
+
+                                <AuthorizeView Policy="Owner">
+                                @* For Role Options Dropdown menu: Included to allow users of role owner to edit owner *@
+
+                                @if (user.ROLE == "Owner")
+                                {
+                                    <Dropdown id="@($"Dropdown-{user.TUID}")" LabelText="Role">
+                                        <DropdownLink Icon="fa-solid fa-pen-to-square" data-bs-toggle="modal"
+                                            data-bs-target="@($"#update-user-modal-{user.TUID}")">Edit</DropdownLink>
+                                        <DropdownLink Icon="fa-regular fa-trash-can" data-bs-toggle="modal"
+                                            data-bs-target="@($"#delete-user-modal-{user.TUID}")">
+                                            Delete
+                                        </DropdownLink>
+                                    </Dropdown>
+                                }
+                                    
                                 </AuthorizeView>
                             </div>
                         </td>
@@ -103,6 +138,7 @@ Andrew Miller (4/22/2025) - Store access - Loader placed into modal
         </table>
     </div>
 
+    @* Update and Delete User Modals *@
     @foreach (var user in users.Skip(1).ToList())
     {
         <AuthorizeView Policy="Manager">
@@ -111,8 +147,10 @@ Andrew Miller (4/22/2025) - Store access - Loader placed into modal
         </AuthorizeView>
     }
 
+    @* Load Message Modal for displaying loader when adding new user*@
     <LoadMessageModal id="load-message" @ref="LoadMessageModal" />
 
+    @* Add User Modal *@
     <AuthorizeView Policy="Manager">
         <AddUserModal id="@($"add-user-modal")" UpdateUsers="UpdateUsers" AddingUser="ToggleLoader"
             ShowLoadingModal="ShowLoadingModal" HideLoadingModal="HideLoadingModal" />
@@ -127,10 +165,23 @@ Andrew Miller (4/22/2025) - Store access - Loader placed into modal
 </div>
 
 @code {
+    /// <summary>
+    /// References LoadMessageModal, used for displaying a loading message when submitting from the
+    /// the Add User Modal
+    /// </summary>
     private LoadMessageModal? LoadMessageModal;
 
+    /// <summary>
+    /// List of users, modeled with UserDTO model. Populates the information on the dashboard
+    /// Information is retrieved from all users from the database via the UpdateUsers method
+    /// </summary>
     private List<Data.Models.Users.UserDTO> users = new List<Data.Models.Users.UserDTO>();
 
+    /// <summary>
+    /// Calls on backend to get all users from the database
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     private async Task UpdateUsers()
     {
         var response = await UsersHttpClient.GetAllUsers();
@@ -141,21 +192,41 @@ Andrew Miller (4/22/2025) - Store access - Loader placed into modal
         }
     }
 
+    /// <summary>
+    /// Updates users on initialization
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     protected override async Task OnInitializedAsync()
     {
         await UpdateUsers();
     }
 
+    /// <summary>
+    /// Formats and properly displays the TUID
+    /// </summary>
+    /// <param name="Id"> Id of user </param>
+    /// <returns> string </returns>
     public string DisplayTUID(int Id)
     {
         return '#' + Id.ToString().PadLeft(10, '0');
     }
 
+    /// <summary>
+    /// Shows the modal defined in LoadMessageModal.razor
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public async Task ShowLoadingModal()
     {
         await LoadMessageModal!.ShowModal();
     }
 
+    /// <summary>
+    /// Hides the modal defined in LoadMessageModal.razor
+    /// </summary>
+    /// <param name=""> no parameters taken </param>
+    /// <returns> void </returns>
     public async Task HideLoadingModal()
     {
         await LoadMessageModal!.HideModal();

--- a/Plot/Components/Pages/UserDashboard/UserDashboard.razor.css
+++ b/Plot/Components/Pages/UserDashboard/UserDashboard.razor.css
@@ -10,13 +10,9 @@ and allocate floorsets for Platos Closet.
 
 Author: Josh Rodack (2/10/2025) */
 
-/* For the original button <button></button> component*/
-
 /* Andrew  Miller - (3/22/2025) */
 
 /* User dashboard */
-
-/* Table columns */
 
 .user-dashboard {
     display: flex;
@@ -25,18 +21,21 @@ Author: Josh Rodack (2/10/2025) */
     box-sizing: border-box;
 }
 
+/* Table in user dashboard */
 .table-set {
     flex-grow: 1;
     height: 95%;
     overflow: auto;
 }
 
+/* Container div for Add User button */
 .add-btn-container {
     align-self: flex-end;
     display: flex;
     margin: 0px;
 }
 
+/* Add User button */
 .add-btn {
     align-self: flex-end;
     width: calc(50/16 * 1rem);


### PR DESCRIPTION
The Role Options dropdown was set to Authorize policy Manager and hid it for Managers and Owners if the user in that row had role as owner.

I added a separate block with Authorize policy Owner and checked within this block if the user's role was owner to allow owner role users to edit owner information. Checking if the user's role was owner so it doesn't create a redundant role options dropdown.

Took the time to update comments throughout the User Dashboard since I was in there. But the only code that changed was in the UserDashboard for editing role options.